### PR TITLE
Add built-in run_python default tool with sandboxed local runner

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,10 +122,16 @@ tools:
       rerank:
         provider: opensource
         top_k: 5
+  - type: run_python
+    config:
+      runner: local_subprocess
+      timeout_s: 20
+      workspace_root: .
+      allow_network: false
 ```
 
 Then pass this to `AgentFactory(..., tools_config=tools)` for `LANGGRAPHCHAT` agents.
-See `docs/tools.md` and `examples/web_search_demo.py` for a runnable example.
+See `docs/tools.md`, `examples/web_search_demo.py`, and `examples/run_python_demo.py` for runnable examples.
 
 ### A2A Server Base Path
 

--- a/README.md
+++ b/README.md
@@ -122,10 +122,16 @@ tools:
       rerank:
         provider: opensource
         top_k: 5
+  - type: run_python
+    config:
+      runner: local_subprocess
+      timeout_s: 20
+      workspace_root: .
+      allow_network: false  # Import-policy toggle only; not runtime network isolation.
 ```
 
 Then pass this to `AgentFactory(..., tools_config=tools)` for `LANGGRAPHCHAT` agents.
-See `docs/tools.md` and `examples/web_search_demo.py` for a runnable example.
+See `docs/tools.md`, `examples/web_search_demo.py`, and `examples/run_python_demo.py` for runnable examples.
 
 ### A2A Server Base Path
 

--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ tools:
       runner: local_subprocess
       timeout_s: 20
       workspace_root: .
-      allow_network: false
+      allow_network: false  # Import-policy toggle only; not runtime network isolation.
 ```
 
 Then pass this to `AgentFactory(..., tools_config=tools)` for `LANGGRAPHCHAT` agents.

--- a/automa_ai/tools/__init__.py
+++ b/automa_ai/tools/__init__.py
@@ -1,6 +1,7 @@
 """Built-in default tools registry."""
 
 from automa_ai.tools.registry import DEFAULT_TOOL_REGISTRY, build_langchain_tools
+from automa_ai.tools.run_python import build_run_python_tool
 from automa_ai.tools.web_search import build_web_search_tool
 
 import logging
@@ -10,6 +11,14 @@ try:
 except ValueError as exc:
     logging.getLogger(__name__).debug(
         "Ignoring ValueError while registering 'web_search' tool: %s",
+        exc,
+    )
+
+try:
+    DEFAULT_TOOL_REGISTRY.register("run_python", build_run_python_tool)
+except ValueError as exc:
+    logging.getLogger(__name__).debug(
+        "Ignoring ValueError while registering 'run_python' tool: %s",
         exc,
     )
 

--- a/automa_ai/tools/run_python/__init__.py
+++ b/automa_ai/tools/run_python/__init__.py
@@ -1,0 +1,3 @@
+from automa_ai.tools.run_python.tool import RunPythonTool, build_run_python_tool
+
+__all__ = ["RunPythonTool", "build_run_python_tool"]

--- a/automa_ai/tools/run_python/config.py
+++ b/automa_ai/tools/run_python/config.py
@@ -15,6 +15,7 @@ class RunPythonToolConfig(BaseModel):
     max_stdout_chars: int = Field(default=20_000, ge=100, le=500_000)
     max_stderr_chars: int = Field(default=20_000, ge=100, le=500_000)
     workspace_root: str | None = None
+    # This toggles import-level checks only and is not runtime network enforcement.
     allow_network: bool = False
     allowed_imports: list[str] = Field(default_factory=list)
     blocked_imports: list[str] = Field(

--- a/automa_ai/tools/run_python/config.py
+++ b/automa_ai/tools/run_python/config.py
@@ -8,7 +8,6 @@ from pydantic import BaseModel, Field
 class RunPythonToolConfig(BaseModel):
     """Runtime configuration for the Python execution tool."""
 
-    enabled: bool = True
     runner: str = "local_subprocess"
     python_executable: str = "python"
     timeout_s: int = Field(default=20, ge=1, le=300)

--- a/automa_ai/tools/run_python/config.py
+++ b/automa_ai/tools/run_python/config.py
@@ -1,0 +1,32 @@
+"""Configuration for the run_python default tool."""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, Field
+
+
+class RunPythonToolConfig(BaseModel):
+    """Runtime configuration for the Python execution tool."""
+
+    enabled: bool = True
+    runner: str = "local_subprocess"
+    python_executable: str = "python"
+    timeout_s: int = Field(default=20, ge=1, le=300)
+    max_stdout_chars: int = Field(default=20_000, ge=100, le=500_000)
+    max_stderr_chars: int = Field(default=20_000, ge=100, le=500_000)
+    workspace_root: str | None = None
+    # This toggles import-level checks only and is not runtime network enforcement.
+    allow_network: bool = False
+    allowed_imports: list[str] = Field(default_factory=list)
+    blocked_imports: list[str] = Field(
+        default_factory=lambda: [
+            "os",
+            "subprocess",
+            "socket",
+            "requests",
+            "urllib",
+            "ctypes",
+        ]
+    )
+    max_artifacts: int = Field(default=10, ge=0, le=100)
+    max_artifact_bytes: int = Field(default=5_000_000, ge=1_000, le=100_000_000)

--- a/automa_ai/tools/run_python/config.py
+++ b/automa_ai/tools/run_python/config.py
@@ -1,0 +1,31 @@
+"""Configuration for the run_python default tool."""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, Field
+
+
+class RunPythonToolConfig(BaseModel):
+    """Runtime configuration for the Python execution tool."""
+
+    enabled: bool = True
+    runner: str = "local_subprocess"
+    python_executable: str = "python"
+    timeout_s: int = Field(default=20, ge=1, le=300)
+    max_stdout_chars: int = Field(default=20_000, ge=100, le=500_000)
+    max_stderr_chars: int = Field(default=20_000, ge=100, le=500_000)
+    workspace_root: str | None = None
+    allow_network: bool = False
+    allowed_imports: list[str] = Field(default_factory=list)
+    blocked_imports: list[str] = Field(
+        default_factory=lambda: [
+            "os",
+            "subprocess",
+            "socket",
+            "requests",
+            "urllib",
+            "ctypes",
+        ]
+    )
+    max_artifacts: int = Field(default=10, ge=0, le=100)
+    max_artifact_bytes: int = Field(default=5_000_000, ge=1_000, le=100_000_000)

--- a/automa_ai/tools/run_python/policy.py
+++ b/automa_ai/tools/run_python/policy.py
@@ -1,0 +1,59 @@
+"""Sandbox policy checks for run_python."""
+
+from __future__ import annotations
+
+import ast
+
+from automa_ai.tools.run_python.config import RunPythonToolConfig
+
+
+class PolicyViolationError(ValueError):
+    """Raised when user code violates sandbox policy."""
+
+
+_BLOCKED_CALLS = {"__import__", "eval", "exec", "compile"}
+_BLOCKED_ATTRS = {"system", "popen", "Popen", "run", "call", "check_output", "check_call"}
+_BLOCKED_BASES = {"os", "subprocess"}
+
+
+def validate_code_policy(code: str, config: RunPythonToolConfig) -> None:
+    """Validate Python code against lightweight static policy checks."""
+    try:
+        tree = ast.parse(code)
+    except SyntaxError as exc:
+        raise PolicyViolationError(f"Invalid Python syntax: {exc}") from exc
+
+    blocked_imports = set(config.blocked_imports)
+    if not config.allow_network:
+        blocked_imports.update({"http", "httpx", "aiohttp", "ftplib", "ssl", "websocket"})
+    allowed_imports = set(config.allowed_imports)
+
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                _validate_import(alias.name, blocked_imports, allowed_imports)
+        elif isinstance(node, ast.ImportFrom):
+            if node.module:
+                _validate_import(node.module, blocked_imports, allowed_imports)
+        elif isinstance(node, ast.Call):
+            if isinstance(node.func, ast.Name) and node.func.id in _BLOCKED_CALLS:
+                raise PolicyViolationError(f"Blocked function call: {node.func.id}")
+            if isinstance(node.func, ast.Attribute):
+                if (
+                    isinstance(node.func.value, ast.Name)
+                    and node.func.value.id in _BLOCKED_BASES
+                    and node.func.attr in _BLOCKED_ATTRS
+                ):
+                    raise PolicyViolationError(
+                        f"Blocked call pattern: {node.func.value.id}.{node.func.attr}"
+                    )
+
+
+def _validate_import(name: str, blocked: set[str], allowed: set[str]) -> None:
+    root = name.split(".", 1)[0]
+    if root in blocked:
+        raise PolicyViolationError(f"Blocked import: {root}")
+    if allowed and root not in allowed:
+        raise PolicyViolationError(
+            f"Import '{root}' is not in allowed_imports policy."
+        )

--- a/automa_ai/tools/run_python/policy.py
+++ b/automa_ai/tools/run_python/policy.py
@@ -1,0 +1,71 @@
+"""Sandbox policy checks for run_python."""
+
+from __future__ import annotations
+
+import ast
+
+from automa_ai.tools.run_python.config import RunPythonToolConfig
+
+
+class PolicyViolationError(ValueError):
+    """Raised when user code violates sandbox policy."""
+
+
+_BLOCKED_CALLS = {"__import__", "eval", "exec", "compile"}
+_BLOCKED_ATTRS = {
+    "system",
+    "popen",
+    "Popen",
+    "run",
+    "call",
+    "check_output",
+    "check_call",
+    "import_module",
+}
+
+
+def validate_code_policy(code: str, config: RunPythonToolConfig) -> None:
+    """Validate Python code against lightweight static policy checks."""
+    try:
+        tree = ast.parse(code)
+    except SyntaxError as exc:
+        raise PolicyViolationError(f"Invalid Python syntax: {exc}") from exc
+
+    blocked_imports = set(config.blocked_imports)
+    if not config.allow_network:
+        blocked_imports.update({"http", "httpx", "aiohttp", "ftplib", "ssl", "websocket"})
+    allowed_imports = set(config.allowed_imports)
+
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                _validate_import(alias.name, blocked_imports, allowed_imports)
+        elif isinstance(node, ast.ImportFrom):
+            if node.module:
+                _validate_import(node.module, blocked_imports, allowed_imports)
+        elif isinstance(node, ast.Call):
+            _validate_call(node)
+
+
+def _validate_call(node: ast.Call) -> None:
+    if isinstance(node.func, ast.Name) and node.func.id in _BLOCKED_CALLS:
+        raise PolicyViolationError(f"Blocked function call: {node.func.id}")
+
+    if isinstance(node.func, ast.Attribute) and node.func.attr in _BLOCKED_ATTRS:
+        raise PolicyViolationError(f"Blocked call pattern: *.{node.func.attr}")
+
+    if isinstance(node.func, ast.Name) and node.func.id == "getattr":
+        if len(node.args) >= 2:
+            second = node.args[1]
+            if isinstance(second, ast.Constant) and second.value == "__import__":
+                raise PolicyViolationError("Blocked dynamic access to __import__.")
+
+
+def _validate_import(name: str, blocked: set[str], allowed: set[str]) -> None:
+    root = name.split(".", 1)[0]
+    if root in blocked:
+        raise PolicyViolationError(f"Blocked import: {root}")
+    if allowed and root not in allowed:
+        raise PolicyViolationError(
+            f"Import '{root}' is not in allowed_imports policy."
+        )

--- a/automa_ai/tools/run_python/runner.py
+++ b/automa_ai/tools/run_python/runner.py
@@ -1,0 +1,253 @@
+"""Execution runner for run_python."""
+
+from __future__ import annotations
+
+import asyncio
+import mimetypes
+import os
+import shutil
+import tempfile
+from dataclasses import dataclass
+from pathlib import Path
+
+from automa_ai.tools.run_python.config import RunPythonToolConfig
+
+
+@dataclass
+class RunResult:
+    success: bool
+    stdout: str
+    stderr: str
+    exit_code: int
+    artifacts: list[dict[str, object]]
+    warnings: list[str]
+
+
+class LocalSubprocessRunner:
+    """Run Python in a temporary workspace using subprocess_exec only."""
+
+    def __init__(self, config: RunPythonToolConfig):
+        self.config = config
+
+    async def run(
+        self,
+        code: str,
+        input_files: list[str],
+        expected_outputs: list[str],
+    ) -> RunResult:
+        warnings: list[str] = []
+        workspace_root = Path(self.config.workspace_root or os.getcwd()).resolve()
+
+        with tempfile.TemporaryDirectory(prefix="run_python_") as tmp:
+            tmp_root = Path(tmp)
+            for rel_path in input_files:
+                src = _resolve_workspace_file(workspace_root, rel_path)
+                dest = _resolve_temp_file(tmp_root, rel_path)
+                dest.parent.mkdir(parents=True, exist_ok=True)
+                shutil.copy2(src, dest)
+
+            baseline = _snapshot_workspace(tmp_root)
+
+            script = tmp_root / "__run_python__.py"
+            script.write_text(
+                _build_wrapped_script(
+                    code=code,
+                    blocked_imports=self.config.blocked_imports,
+                    allow_network=self.config.allow_network,
+                ),
+                encoding="utf-8",
+            )
+            env = _build_subprocess_env()
+
+            process = await asyncio.create_subprocess_exec(
+                self.config.python_executable,
+                "-I",
+                "-B",
+                str(script.name),
+                cwd=str(tmp_root),
+                env=env,
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.PIPE,
+            )
+            try:
+                stdout_b, stderr_b = await asyncio.wait_for(
+                    process.communicate(), timeout=self.config.timeout_s
+                )
+                exit_code = process.returncode
+                success = exit_code == 0
+            except asyncio.TimeoutError:
+                process.kill()
+                await process.wait()
+                stdout_b, stderr_b = b"", b"Execution timed out."
+                exit_code = 124
+                success = False
+                warnings.append("Execution timed out and the process was terminated.")
+
+            stdout = stdout_b.decode("utf-8", errors="replace")
+            stderr = stderr_b.decode("utf-8", errors="replace")
+            stdout = _truncate(stdout, self.config.max_stdout_chars, "stdout", warnings)
+            stderr = _truncate(stderr, self.config.max_stderr_chars, "stderr", warnings)
+
+            artifacts = _collect_artifacts(
+                root=tmp_root,
+                expected_outputs=expected_outputs,
+                max_artifacts=self.config.max_artifacts,
+                max_artifact_bytes=self.config.max_artifact_bytes,
+                warnings=warnings,
+                baseline=baseline,
+            )
+
+            return RunResult(
+                success=success,
+                stdout=stdout,
+                stderr=stderr,
+                exit_code=exit_code,
+                artifacts=artifacts,
+                warnings=warnings,
+            )
+
+
+def _snapshot_workspace(root: Path) -> dict[str, tuple[int, int]]:
+    snapshot: dict[str, tuple[int, int]] = {}
+    for path in root.rglob("*"):
+        if not path.is_file():
+            continue
+        stat = path.stat()
+        snapshot[str(path.relative_to(root))] = (stat.st_size, stat.st_mtime_ns)
+    return snapshot
+
+
+def _collect_artifacts(
+    root: Path,
+    expected_outputs: list[str],
+    max_artifacts: int,
+    max_artifact_bytes: int,
+    warnings: list[str],
+    baseline: dict[str, tuple[int, int]],
+) -> list[dict[str, object]]:
+    if max_artifacts <= 0:
+        return []
+
+    results: list[dict[str, object]] = []
+    candidates: list[Path] = []
+
+    if expected_outputs:
+        for rel in expected_outputs:
+            path = _resolve_temp_file(root, rel)
+            if path.exists() and path.is_file():
+                candidates.append(path)
+            else:
+                warnings.append(f"Expected output was not found: {rel}")
+    else:
+        for path in root.rglob("*"):
+            if not path.is_file() or path.name == "__run_python__.py":
+                continue
+            rel_path = str(path.relative_to(root))
+            stat = path.stat()
+            current = (stat.st_size, stat.st_mtime_ns)
+            if rel_path in baseline and baseline[rel_path] == current:
+                continue
+            candidates.append(path)
+
+    for path in candidates:
+        if len(results) >= max_artifacts:
+            warnings.append("Artifact limit reached; some files were not returned.")
+            break
+        size = path.stat().st_size
+        if size > max_artifact_bytes:
+            warnings.append(f"Artifact exceeds max_artifact_bytes and was skipped: {path}")
+            continue
+        rel_path = str(path.relative_to(root))
+        mime_type, _ = mimetypes.guess_type(path.name)
+        results.append(
+            {
+                "path": rel_path,
+                "size_bytes": size,
+                "mime_type": mime_type,
+            }
+        )
+    return results
+
+
+def _resolve_workspace_file(workspace_root: Path, rel_path: str) -> Path:
+    path = (workspace_root / rel_path).resolve()
+    if workspace_root not in path.parents and path != workspace_root:
+        raise ValueError(f"Input path must stay within workspace_root: {rel_path}")
+    if not path.exists() or not path.is_file():
+        raise ValueError(f"Input file does not exist: {rel_path}")
+    return path
+
+
+def _resolve_temp_file(temp_root: Path, rel_path: str) -> Path:
+    path = (temp_root / rel_path).resolve()
+    if temp_root not in path.parents and path != temp_root:
+        raise ValueError(f"Path must stay within temporary workspace: {rel_path}")
+    return path
+
+
+def _truncate(value: str, max_chars: int, label: str, warnings: list[str]) -> str:
+    if len(value) <= max_chars:
+        return value
+    warnings.append(f"{label} was truncated to {max_chars} characters.")
+    return value[:max_chars]
+
+
+def _build_subprocess_env() -> dict[str, str]:
+    """Build a minimal but platform-safe environment for Python subprocesses."""
+    allowed = {
+        "PATH",
+        "SYSTEMROOT",
+        "WINDIR",
+        "TMP",
+        "TEMP",
+        "HOME",
+        "USERPROFILE",
+        "LANG",
+        "LC_ALL",
+    }
+    env: dict[str, str] = {}
+    for key in allowed:
+        value = os.environ.get(key)
+        if value:
+            env[key] = value
+    env["PYTHONNOUSERSITE"] = "1"
+    env["MPLBACKEND"] = "Agg"
+    env.setdefault("PYTHONIOENCODING", "utf-8")
+    return env
+
+
+def _build_wrapped_script(
+    code: str,
+    blocked_imports: list[str],
+    allow_network: bool,
+) -> str:
+    blocked = sorted(set(blocked_imports))
+    return f"""
+import builtins
+import sys
+
+_BLOCKED_IMPORTS = {blocked!r}
+_ALLOW_NETWORK = {allow_network!r}
+_REAL_IMPORT = builtins.__import__
+
+
+def _guarded_import(name, globals=None, locals=None, fromlist=(), level=0):
+    root = name.split('.', 1)[0]
+    if root in _BLOCKED_IMPORTS:
+        raise ImportError(f"Blocked import: {{root}}")
+    return _REAL_IMPORT(name, globals, locals, fromlist, level)
+
+
+def _audit(event, args):
+    if event in {{'os.system', 'subprocess.Popen'}}:
+        raise RuntimeError(f"Blocked runtime operation: {{event}}")
+    if not _ALLOW_NETWORK and event.startswith('socket.'):
+        raise RuntimeError(f"Blocked runtime network operation: {{event}}")
+
+
+builtins.__import__ = _guarded_import
+sys.addaudithook(_audit)
+
+namespace = {{'__name__': '__main__', '__builtins__': builtins.__dict__}}
+exec(compile({code!r}, '<run_python>', 'exec'), namespace, namespace)
+""".lstrip()

--- a/automa_ai/tools/run_python/runner.py
+++ b/automa_ai/tools/run_python/runner.py
@@ -40,19 +40,17 @@ class LocalSubprocessRunner:
 
         with tempfile.TemporaryDirectory(prefix="run_python_") as tmp:
             tmp_root = Path(tmp)
+            copied_inputs: set[str] = set()
             for rel_path in input_files:
                 src = _resolve_workspace_file(workspace_root, rel_path)
                 dest = _resolve_temp_file(tmp_root, rel_path)
                 dest.parent.mkdir(parents=True, exist_ok=True)
                 shutil.copy2(src, dest)
+                copied_inputs.add(str(dest.relative_to(tmp_root)))
 
             script = tmp_root / "__run_python__.py"
             script.write_text(code, encoding="utf-8")
-            env = {
-                "PYTHONNOUSERSITE": "1",
-                "MPLBACKEND": "Agg",
-                "PATH": os.environ.get("PATH", ""),
-            }
+            env = _build_subprocess_env()
 
             process = await asyncio.create_subprocess_exec(
                 self.config.python_executable,
@@ -89,6 +87,7 @@ class LocalSubprocessRunner:
                 max_artifacts=self.config.max_artifacts,
                 max_artifact_bytes=self.config.max_artifact_bytes,
                 warnings=warnings,
+                excluded_paths=copied_inputs,
             )
 
             return RunResult(
@@ -107,7 +106,11 @@ def _collect_artifacts(
     max_artifacts: int,
     max_artifact_bytes: int,
     warnings: list[str],
+    excluded_paths: set[str],
 ) -> list[dict[str, object]]:
+    if max_artifacts == 0:
+        return []
+
     results: list[dict[str, object]] = []
     candidates: list[Path] = []
 
@@ -120,8 +123,12 @@ def _collect_artifacts(
                 warnings.append(f"Expected output was not found: {rel}")
     else:
         for path in root.rglob("*"):
-            if path.is_file() and path.name != "__run_python__.py":
-                candidates.append(path)
+            if not path.is_file() or path.name == "__run_python__.py":
+                continue
+            rel_path = str(path.relative_to(root))
+            if rel_path in excluded_paths:
+                continue
+            candidates.append(path)
 
     for path in candidates:
         if len(results) >= max_artifacts:
@@ -164,3 +171,27 @@ def _truncate(value: str, max_chars: int, label: str, warnings: list[str]) -> st
         return value
     warnings.append(f"{label} was truncated to {max_chars} characters.")
     return value[:max_chars]
+
+
+def _build_subprocess_env() -> dict[str, str]:
+    """Build a minimal but platform-safe environment for Python subprocesses."""
+    allowed = {
+        "PATH",
+        "SYSTEMROOT",
+        "WINDIR",
+        "TMP",
+        "TEMP",
+        "HOME",
+        "USERPROFILE",
+        "LANG",
+        "LC_ALL",
+    }
+    env: dict[str, str] = {}
+    for key in allowed:
+        value = os.environ.get(key)
+        if value:
+            env[key] = value
+    env["PYTHONNOUSERSITE"] = "1"
+    env["MPLBACKEND"] = "Agg"
+    env.setdefault("PYTHONIOENCODING", "utf-8")
+    return env

--- a/automa_ai/tools/run_python/runner.py
+++ b/automa_ai/tools/run_python/runner.py
@@ -1,0 +1,166 @@
+"""Execution runner for run_python."""
+
+from __future__ import annotations
+
+import asyncio
+import mimetypes
+import os
+import shutil
+import tempfile
+from dataclasses import dataclass
+from pathlib import Path
+
+from automa_ai.tools.run_python.config import RunPythonToolConfig
+
+
+@dataclass
+class RunResult:
+    success: bool
+    stdout: str
+    stderr: str
+    exit_code: int
+    artifacts: list[dict[str, object]]
+    warnings: list[str]
+
+
+class LocalSubprocessRunner:
+    """Run Python in a temporary workspace using subprocess_exec only."""
+
+    def __init__(self, config: RunPythonToolConfig):
+        self.config = config
+
+    async def run(
+        self,
+        code: str,
+        input_files: list[str],
+        expected_outputs: list[str],
+    ) -> RunResult:
+        warnings: list[str] = []
+        workspace_root = Path(self.config.workspace_root or os.getcwd()).resolve()
+
+        with tempfile.TemporaryDirectory(prefix="run_python_") as tmp:
+            tmp_root = Path(tmp)
+            for rel_path in input_files:
+                src = _resolve_workspace_file(workspace_root, rel_path)
+                dest = _resolve_temp_file(tmp_root, rel_path)
+                dest.parent.mkdir(parents=True, exist_ok=True)
+                shutil.copy2(src, dest)
+
+            script = tmp_root / "__run_python__.py"
+            script.write_text(code, encoding="utf-8")
+            env = {
+                "PYTHONNOUSERSITE": "1",
+                "MPLBACKEND": "Agg",
+                "PATH": os.environ.get("PATH", ""),
+            }
+
+            process = await asyncio.create_subprocess_exec(
+                self.config.python_executable,
+                "-I",
+                "-B",
+                str(script.name),
+                cwd=str(tmp_root),
+                env=env,
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.PIPE,
+            )
+            try:
+                stdout_b, stderr_b = await asyncio.wait_for(
+                    process.communicate(), timeout=self.config.timeout_s
+                )
+                exit_code = process.returncode
+                success = exit_code == 0
+            except asyncio.TimeoutError:
+                process.kill()
+                await process.wait()
+                stdout_b, stderr_b = b"", b"Execution timed out."
+                exit_code = 124
+                success = False
+                warnings.append("Execution timed out and the process was terminated.")
+
+            stdout = stdout_b.decode("utf-8", errors="replace")
+            stderr = stderr_b.decode("utf-8", errors="replace")
+            stdout = _truncate(stdout, self.config.max_stdout_chars, "stdout", warnings)
+            stderr = _truncate(stderr, self.config.max_stderr_chars, "stderr", warnings)
+
+            artifacts = _collect_artifacts(
+                root=tmp_root,
+                expected_outputs=expected_outputs,
+                max_artifacts=self.config.max_artifacts,
+                max_artifact_bytes=self.config.max_artifact_bytes,
+                warnings=warnings,
+            )
+
+            return RunResult(
+                success=success,
+                stdout=stdout,
+                stderr=stderr,
+                exit_code=exit_code,
+                artifacts=artifacts,
+                warnings=warnings,
+            )
+
+
+def _collect_artifacts(
+    root: Path,
+    expected_outputs: list[str],
+    max_artifacts: int,
+    max_artifact_bytes: int,
+    warnings: list[str],
+) -> list[dict[str, object]]:
+    results: list[dict[str, object]] = []
+    candidates: list[Path] = []
+
+    if expected_outputs:
+        for rel in expected_outputs:
+            path = _resolve_temp_file(root, rel)
+            if path.exists() and path.is_file():
+                candidates.append(path)
+            else:
+                warnings.append(f"Expected output was not found: {rel}")
+    else:
+        for path in root.rglob("*"):
+            if path.is_file() and path.name != "__run_python__.py":
+                candidates.append(path)
+
+    for path in candidates:
+        if len(results) >= max_artifacts:
+            warnings.append("Artifact limit reached; some files were not returned.")
+            break
+        size = path.stat().st_size
+        if size > max_artifact_bytes:
+            warnings.append(f"Artifact exceeds max_artifact_bytes and was skipped: {path}")
+            continue
+        rel_path = str(path.relative_to(root))
+        mime_type, _ = mimetypes.guess_type(path.name)
+        results.append(
+            {
+                "path": rel_path,
+                "size_bytes": size,
+                "mime_type": mime_type,
+            }
+        )
+    return results
+
+
+def _resolve_workspace_file(workspace_root: Path, rel_path: str) -> Path:
+    path = (workspace_root / rel_path).resolve()
+    if workspace_root not in path.parents and path != workspace_root:
+        raise ValueError(f"Input path must stay within workspace_root: {rel_path}")
+    if not path.exists() or not path.is_file():
+        raise ValueError(f"Input file does not exist: {rel_path}")
+    return path
+
+
+def _resolve_temp_file(temp_root: Path, rel_path: str) -> Path:
+    path = (temp_root / rel_path).resolve()
+    if temp_root not in path.parents and path != temp_root:
+        raise ValueError(f"Path must stay within temporary workspace: {rel_path}")
+    return path
+
+
+def _truncate(value: str, max_chars: int, label: str, warnings: list[str]) -> str:
+    if len(value) <= max_chars:
+        return value
+    warnings.append(f"{label} was truncated to {max_chars} characters.")
+    return value[:max_chars]

--- a/automa_ai/tools/run_python/runner.py
+++ b/automa_ai/tools/run_python/runner.py
@@ -108,7 +108,7 @@ def _collect_artifacts(
     warnings: list[str],
     excluded_paths: set[str],
 ) -> list[dict[str, object]]:
-    if max_artifacts == 0:
+    if max_artifacts <= 0:
         return []
 
     results: list[dict[str, object]] = []

--- a/automa_ai/tools/run_python/runner.py
+++ b/automa_ai/tools/run_python/runner.py
@@ -1,0 +1,265 @@
+"""Execution runner for run_python."""
+
+from __future__ import annotations
+
+import asyncio
+import mimetypes
+import os
+import shutil
+import tempfile
+from dataclasses import dataclass
+from pathlib import Path
+
+from automa_ai.tools.run_python.config import RunPythonToolConfig
+
+_RESERVED_INPUT_FILENAMES = {"sitecustomize.py", "usercustomize.py"}
+_RESERVED_INPUT_SUFFIXES = {".pth"}
+
+
+@dataclass
+class RunResult:
+    success: bool
+    stdout: str
+    stderr: str
+    exit_code: int
+    artifacts: list[dict[str, object]]
+    warnings: list[str]
+
+
+class LocalSubprocessRunner:
+    """Run Python in a temporary workspace using subprocess_exec only."""
+
+    def __init__(self, config: RunPythonToolConfig):
+        self.config = config
+
+    async def run(
+        self,
+        code: str,
+        input_files: list[str],
+        expected_outputs: list[str],
+    ) -> RunResult:
+        warnings: list[str] = []
+        workspace_root = Path(self.config.workspace_root or os.getcwd()).resolve()
+
+        with tempfile.TemporaryDirectory(prefix="run_python_") as tmp:
+            tmp_root = Path(tmp)
+            for rel_path in input_files:
+                _validate_input_filename(rel_path)
+                src = _resolve_workspace_file(workspace_root, rel_path)
+                dest = _resolve_temp_file(tmp_root, rel_path)
+                dest.parent.mkdir(parents=True, exist_ok=True)
+                shutil.copy2(src, dest)
+
+            baseline = _snapshot_workspace(tmp_root)
+
+            script = tmp_root / "__run_python__.py"
+            script.write_text(
+                _build_wrapped_script(
+                    code=code,
+                    blocked_imports=self.config.blocked_imports,
+                    allow_network=self.config.allow_network,
+                ),
+                encoding="utf-8",
+            )
+            env = _build_subprocess_env()
+
+            process = await asyncio.create_subprocess_exec(
+                self.config.python_executable,
+                "-I",
+                "-B",
+                str(script.name),
+                cwd=str(tmp_root),
+                env=env,
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.PIPE,
+            )
+            try:
+                stdout_b, stderr_b = await asyncio.wait_for(
+                    process.communicate(), timeout=self.config.timeout_s
+                )
+                exit_code = process.returncode
+                success = exit_code == 0
+            except asyncio.TimeoutError:
+                process.kill()
+                await process.wait()
+                stdout_b, stderr_b = b"", b"Execution timed out."
+                exit_code = 124
+                success = False
+                warnings.append("Execution timed out and the process was terminated.")
+
+            stdout = stdout_b.decode("utf-8", errors="replace")
+            stderr = stderr_b.decode("utf-8", errors="replace")
+            stdout = _truncate(stdout, self.config.max_stdout_chars, "stdout", warnings)
+            stderr = _truncate(stderr, self.config.max_stderr_chars, "stderr", warnings)
+
+            artifacts = _collect_artifacts(
+                root=tmp_root,
+                expected_outputs=expected_outputs,
+                max_artifacts=self.config.max_artifacts,
+                max_artifact_bytes=self.config.max_artifact_bytes,
+                warnings=warnings,
+                baseline=baseline,
+            )
+
+            return RunResult(
+                success=success,
+                stdout=stdout,
+                stderr=stderr,
+                exit_code=exit_code,
+                artifacts=artifacts,
+                warnings=warnings,
+            )
+
+
+def _snapshot_workspace(root: Path) -> dict[str, tuple[int, int]]:
+    snapshot: dict[str, tuple[int, int]] = {}
+    for path in root.rglob("*"):
+        if not path.is_file():
+            continue
+        stat = path.stat()
+        snapshot[str(path.relative_to(root))] = (stat.st_size, stat.st_mtime_ns)
+    return snapshot
+
+
+def _collect_artifacts(
+    root: Path,
+    expected_outputs: list[str],
+    max_artifacts: int,
+    max_artifact_bytes: int,
+    warnings: list[str],
+    baseline: dict[str, tuple[int, int]],
+) -> list[dict[str, object]]:
+    if max_artifacts <= 0:
+        return []
+
+    results: list[dict[str, object]] = []
+    candidates: list[Path] = []
+
+    if expected_outputs:
+        for rel in expected_outputs:
+            path = _resolve_temp_file(root, rel)
+            if path.exists() and path.is_file():
+                candidates.append(path)
+            else:
+                warnings.append(f"Expected output was not found: {rel}")
+    else:
+        for path in root.rglob("*"):
+            if not path.is_file() or path.name == "__run_python__.py":
+                continue
+            rel_path = str(path.relative_to(root))
+            stat = path.stat()
+            current = (stat.st_size, stat.st_mtime_ns)
+            if rel_path in baseline and baseline[rel_path] == current:
+                continue
+            candidates.append(path)
+
+    for path in candidates:
+        if len(results) >= max_artifacts:
+            warnings.append("Artifact limit reached; some files were not returned.")
+            break
+        size = path.stat().st_size
+        if size > max_artifact_bytes:
+            warnings.append(f"Artifact exceeds max_artifact_bytes and was skipped: {path}")
+            continue
+        rel_path = str(path.relative_to(root))
+        mime_type, _ = mimetypes.guess_type(path.name)
+        results.append(
+            {
+                "path": rel_path,
+                "size_bytes": size,
+                "mime_type": mime_type,
+            }
+        )
+    return results
+
+
+def _validate_input_filename(rel_path: str) -> None:
+    filename = Path(rel_path).name.lower()
+    if filename in _RESERVED_INPUT_FILENAMES:
+        raise ValueError(f"Reserved input filename is not allowed: {filename}")
+    if Path(filename).suffix.lower() in _RESERVED_INPUT_SUFFIXES:
+        raise ValueError(f"Reserved input file extension is not allowed: {filename}")
+
+
+def _resolve_workspace_file(workspace_root: Path, rel_path: str) -> Path:
+    path = (workspace_root / rel_path).resolve()
+    if workspace_root not in path.parents and path != workspace_root:
+        raise ValueError(f"Input path must stay within workspace_root: {rel_path}")
+    if not path.exists() or not path.is_file():
+        raise ValueError(f"Input file does not exist: {rel_path}")
+    return path
+
+
+def _resolve_temp_file(temp_root: Path, rel_path: str) -> Path:
+    path = (temp_root / rel_path).resolve()
+    if temp_root not in path.parents and path != temp_root:
+        raise ValueError(f"Path must stay within temporary workspace: {rel_path}")
+    return path
+
+
+def _truncate(value: str, max_chars: int, label: str, warnings: list[str]) -> str:
+    if len(value) <= max_chars:
+        return value
+    warnings.append(f"{label} was truncated to {max_chars} characters.")
+    return value[:max_chars]
+
+
+def _build_subprocess_env() -> dict[str, str]:
+    """Build a minimal but platform-safe environment for Python subprocesses."""
+    allowed = {
+        "PATH",
+        "SYSTEMROOT",
+        "WINDIR",
+        "TMP",
+        "TEMP",
+        "HOME",
+        "USERPROFILE",
+        "LANG",
+        "LC_ALL",
+    }
+    env: dict[str, str] = {}
+    for key in allowed:
+        value = os.environ.get(key)
+        if value:
+            env[key] = value
+    env["PYTHONNOUSERSITE"] = "1"
+    env["MPLBACKEND"] = "Agg"
+    env.setdefault("PYTHONIOENCODING", "utf-8")
+    return env
+
+
+def _build_wrapped_script(
+    code: str,
+    blocked_imports: list[str],
+    allow_network: bool,
+) -> str:
+    blocked = sorted(set(blocked_imports))
+    return f"""
+import builtins
+import sys
+
+_BLOCKED_IMPORTS = {blocked!r}
+_ALLOW_NETWORK = {allow_network!r}
+_REAL_IMPORT = builtins.__import__
+
+
+def _guarded_import(name, globals=None, locals=None, fromlist=(), level=0):
+    root = name.split('.', 1)[0]
+    if root in _BLOCKED_IMPORTS:
+        raise ImportError(f"Blocked import: {{root}}")
+    return _REAL_IMPORT(name, globals, locals, fromlist, level)
+
+
+def _audit(event, args):
+    if event in {{'os.system', 'subprocess.Popen'}}:
+        raise RuntimeError(f"Blocked runtime operation: {{event}}")
+    if not _ALLOW_NETWORK and event.startswith('socket.'):
+        raise RuntimeError(f"Blocked runtime network operation: {{event}}")
+
+
+builtins.__import__ = _guarded_import
+sys.addaudithook(_audit)
+
+namespace = {{'__name__': '__main__', '__builtins__': builtins.__dict__}}
+exec(compile({code!r}, '<run_python>', 'exec'), namespace, namespace)
+""".lstrip()

--- a/automa_ai/tools/run_python/tool.py
+++ b/automa_ai/tools/run_python/tool.py
@@ -95,8 +95,6 @@ class RunPythonTool(BaseDefaultTool):
 
 def build_run_python_tool(config: dict[str, Any], _runtime_deps: Any) -> RunPythonTool:
     parsed = RunPythonToolConfig.model_validate(config)
-    if not parsed.enabled:
-        raise ValueError("run_python tool is disabled by configuration.")
     if parsed.runner != "local_subprocess":
         raise ValueError(f"Unsupported run_python runner: {parsed.runner}")
     return RunPythonTool(parsed)

--- a/automa_ai/tools/run_python/tool.py
+++ b/automa_ai/tools/run_python/tool.py
@@ -1,0 +1,102 @@
+"""run_python default tool."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from pydantic import BaseModel, Field
+
+from automa_ai.tools.base import BaseDefaultTool
+from automa_ai.tools.run_python.config import RunPythonToolConfig
+from automa_ai.tools.run_python.policy import PolicyViolationError, validate_code_policy
+from automa_ai.tools.run_python.runner import LocalSubprocessRunner
+
+
+class RunPythonInput(BaseModel):
+    code: str = Field(min_length=1)
+    input_files: list[str] = Field(default_factory=list)
+    expected_outputs: list[str] = Field(default_factory=list)
+    timeout_s: int | None = Field(default=None, ge=1, le=300)
+
+
+class RunPythonTool(BaseDefaultTool):
+    type = "run_python"
+
+    def __init__(self, config: RunPythonToolConfig):
+        self.config = config
+
+    @property
+    def args_schema(self) -> type[BaseModel]:
+        return RunPythonInput
+
+    @property
+    def description(self) -> str:
+        return (
+            "Execute Python for calculations, structured-data parsing, charts/tables, "
+            "file transformations, and simulation preparation logic using a best-effort "
+            "sandbox policy. Not for untrusted code."
+        )
+
+    async def invoke(self, payload: dict[str, Any]) -> dict[str, Any]:
+        args = RunPythonInput.model_validate(payload)
+        if args.timeout_s is not None:
+            timeout_s = min(args.timeout_s, self.config.timeout_s)
+            cfg = self.config.model_copy(update={"timeout_s": timeout_s})
+        else:
+            cfg = self.config
+
+        try:
+            validate_code_policy(args.code, cfg)
+        except PolicyViolationError as exc:
+            return {
+                "success": False,
+                "stdout": "",
+                "stderr": str(exc),
+                "exit_code": 1,
+                "artifacts": [],
+                "meta": {
+                    "runner": cfg.runner,
+                    "warnings": ["Execution blocked by sandbox policy."],
+                },
+            }
+
+        runner = LocalSubprocessRunner(cfg)
+        try:
+            result = await runner.run(
+                code=args.code,
+                input_files=args.input_files,
+                expected_outputs=args.expected_outputs,
+            )
+        except (ValueError, OSError) as exc:
+            return {
+                "success": False,
+                "stdout": "",
+                "stderr": str(exc),
+                "exit_code": 1,
+                "artifacts": [],
+                "meta": {
+                    "runner": cfg.runner,
+                    "warnings": ["Execution failed before Python process start."],
+                },
+            }
+
+        return {
+            "success": result.success,
+            "stdout": result.stdout,
+            "stderr": result.stderr,
+            "exit_code": result.exit_code,
+            "artifacts": result.artifacts,
+            "meta": {
+                "runner": cfg.runner,
+                "warnings": result.warnings,
+            },
+        }
+
+
+def build_run_python_tool(config: dict[str, Any], _runtime_deps: Any) -> RunPythonTool:
+    parsed = RunPythonToolConfig.model_validate(config)
+    if not parsed.enabled:
+        raise ValueError("run_python tool is disabled by configuration.")
+    if parsed.runner != "local_subprocess":
+        raise ValueError(f"Unsupported run_python runner: {parsed.runner}")
+    return RunPythonTool(parsed)

--- a/automa_ai/tools/run_python/tool.py
+++ b/automa_ai/tools/run_python/tool.py
@@ -1,0 +1,87 @@
+"""run_python default tool."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from pydantic import BaseModel, Field
+
+from automa_ai.tools.base import BaseDefaultTool
+from automa_ai.tools.run_python.config import RunPythonToolConfig
+from automa_ai.tools.run_python.policy import PolicyViolationError, validate_code_policy
+from automa_ai.tools.run_python.runner import LocalSubprocessRunner
+
+
+class RunPythonInput(BaseModel):
+    code: str = Field(min_length=1)
+    input_files: list[str] = Field(default_factory=list)
+    expected_outputs: list[str] = Field(default_factory=list)
+    timeout_s: int | None = Field(default=None, ge=1, le=300)
+
+
+class RunPythonTool(BaseDefaultTool):
+    type = "run_python"
+
+    def __init__(self, config: RunPythonToolConfig):
+        self.config = config
+
+    @property
+    def args_schema(self) -> type[BaseModel]:
+        return RunPythonInput
+
+    @property
+    def description(self) -> str:
+        return (
+            "Execute Python for calculations, structured-data parsing, charts/tables, "
+            "file transformations, and simulation preparation logic. No shell access."
+        )
+
+    async def invoke(self, payload: dict[str, Any]) -> dict[str, Any]:
+        args = RunPythonInput.model_validate(payload)
+        if args.timeout_s is not None:
+            timeout_s = min(args.timeout_s, self.config.timeout_s)
+            cfg = self.config.model_copy(update={"timeout_s": timeout_s})
+        else:
+            cfg = self.config
+
+        try:
+            validate_code_policy(args.code, cfg)
+        except PolicyViolationError as exc:
+            return {
+                "success": False,
+                "stdout": "",
+                "stderr": str(exc),
+                "exit_code": 1,
+                "artifacts": [],
+                "meta": {
+                    "runner": cfg.runner,
+                    "warnings": ["Execution blocked by sandbox policy."],
+                },
+            }
+
+        runner = LocalSubprocessRunner(cfg)
+        result = await runner.run(
+            code=args.code,
+            input_files=args.input_files,
+            expected_outputs=args.expected_outputs,
+        )
+        return {
+            "success": result.success,
+            "stdout": result.stdout,
+            "stderr": result.stderr,
+            "exit_code": result.exit_code,
+            "artifacts": result.artifacts,
+            "meta": {
+                "runner": cfg.runner,
+                "warnings": result.warnings,
+            },
+        }
+
+
+def build_run_python_tool(config: dict[str, Any], _runtime_deps: Any) -> RunPythonTool:
+    parsed = RunPythonToolConfig.model_validate(config)
+    if not parsed.enabled:
+        raise ValueError("run_python tool is disabled by configuration.")
+    if parsed.runner != "local_subprocess":
+        raise ValueError(f"Unsupported run_python runner: {parsed.runner}")
+    return RunPythonTool(parsed)

--- a/automa_ai/tools/run_python/tool.py
+++ b/automa_ai/tools/run_python/tool.py
@@ -33,7 +33,8 @@ class RunPythonTool(BaseDefaultTool):
     def description(self) -> str:
         return (
             "Execute Python for calculations, structured-data parsing, charts/tables, "
-            "file transformations, and simulation preparation logic. No shell access."
+            "file transformations, and simulation preparation logic using a best-effort "
+            "sandbox policy. Not for untrusted code."
         )
 
     async def invoke(self, payload: dict[str, Any]) -> dict[str, Any]:

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -42,6 +42,59 @@ Output format:
 - `results`: list of `{title, url, snippet, content?, score?, source}`
 - `meta`: `{provider_used, reranker_used, timings, warnings}`
 
+
+## Built-in tool: `run_python`
+
+Input fields:
+- `code` (required)
+- `input_files` (default `[]`)
+- `expected_outputs` (default `[]`; if omitted, only files newly created/modified by execution are returned)
+- `timeout_s` (optional, capped by tool config)
+
+Output format:
+- `success`, `stdout`, `stderr`, `exit_code`
+- `artifacts`: list of `{path, size_bytes, mime_type}`
+- `meta`: `{runner, warnings}`
+
+Configuration fields:
+- `enabled` (default `true`)
+- `runner` (default `local_subprocess`)
+- `python_executable` (default `python`)
+- `timeout_s` (default `20`)
+- `max_stdout_chars`, `max_stderr_chars`
+- `workspace_root`
+- `allow_network` (controls import-policy checks only; it is not runtime network isolation)
+- `allowed_imports`, `blocked_imports`
+- `max_artifacts`, `max_artifact_bytes`
+
+Sandbox limitations:
+- Runs Python only with a local subprocess runner.
+- Uses best-effort static policy checks; it is not a hardened sandbox for untrusted code.
+- Does not expose shell or bash execution.
+- Rejects blocked imports and known dangerous call patterns before execution.
+- Rejects reserved startup file names (`sitecustomize.py`, `usercustomize.py`, and `.pth`) in `input_files`.
+- Enforces timeout and output truncation.
+- Executes code in a temporary working directory and only returns files from that directory.
+
+Example config:
+
+```yaml
+tools:
+  - type: run_python
+    config:
+      runner: local_subprocess
+      timeout_s: 20
+      workspace_root: .
+      allow_network: false
+      blocked_imports:
+        - os
+        - subprocess
+        - socket
+        - requests
+        - urllib
+        - ctypes
+```
+
 ## Provider behavior
 
 - Search providers:

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -42,6 +42,57 @@ Output format:
 - `results`: list of `{title, url, snippet, content?, score?, source}`
 - `meta`: `{provider_used, reranker_used, timings, warnings}`
 
+
+## Built-in tool: `run_python`
+
+Input fields:
+- `code` (required)
+- `input_files` (default `[]`)
+- `expected_outputs` (default `[]`)
+- `timeout_s` (optional, capped by tool config)
+
+Output format:
+- `success`, `stdout`, `stderr`, `exit_code`
+- `artifacts`: list of `{path, size_bytes, mime_type}`
+- `meta`: `{runner, warnings}`
+
+Configuration fields:
+- `enabled` (default `true`)
+- `runner` (default `local_subprocess`)
+- `python_executable` (default `python`)
+- `timeout_s` (default `20`)
+- `max_stdout_chars`, `max_stderr_chars`
+- `workspace_root`
+- `allow_network`
+- `allowed_imports`, `blocked_imports`
+- `max_artifacts`, `max_artifact_bytes`
+
+Sandbox limitations:
+- Runs Python only with a local subprocess runner.
+- Does not expose shell or bash execution.
+- Rejects blocked imports and known dangerous call patterns before execution.
+- Enforces timeout and output truncation.
+- Executes code in a temporary working directory and only returns files from that directory.
+
+Example config:
+
+```yaml
+tools:
+  - type: run_python
+    config:
+      runner: local_subprocess
+      timeout_s: 20
+      workspace_root: .
+      allow_network: false
+      blocked_imports:
+        - os
+        - subprocess
+        - socket
+        - requests
+        - urllib
+        - ctypes
+```
+
 ## Provider behavior
 
 - Search providers:

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -63,12 +63,13 @@ Configuration fields:
 - `timeout_s` (default `20`)
 - `max_stdout_chars`, `max_stderr_chars`
 - `workspace_root`
-- `allow_network`
+- `allow_network` (controls import-policy checks only; it is not runtime network isolation)
 - `allowed_imports`, `blocked_imports`
 - `max_artifacts`, `max_artifact_bytes`
 
 Sandbox limitations:
 - Runs Python only with a local subprocess runner.
+- Uses best-effort static policy checks; it is not a hardened sandbox for untrusted code.
 - Does not expose shell or bash execution.
 - Rejects blocked imports and known dangerous call patterns before execution.
 - Enforces timeout and output truncation.

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -57,7 +57,6 @@ Output format:
 - `meta`: `{runner, warnings}`
 
 Configuration fields:
-- `enabled` (default `true`)
 - `runner` (default `local_subprocess`)
 - `python_executable` (default `python`)
 - `timeout_s` (default `20`)

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -42,6 +42,58 @@ Output format:
 - `results`: list of `{title, url, snippet, content?, score?, source}`
 - `meta`: `{provider_used, reranker_used, timings, warnings}`
 
+
+## Built-in tool: `run_python`
+
+Input fields:
+- `code` (required)
+- `input_files` (default `[]`)
+- `expected_outputs` (default `[]`; if omitted, only files newly created/modified by execution are returned)
+- `timeout_s` (optional, capped by tool config)
+
+Output format:
+- `success`, `stdout`, `stderr`, `exit_code`
+- `artifacts`: list of `{path, size_bytes, mime_type}`
+- `meta`: `{runner, warnings}`
+
+Configuration fields:
+- `enabled` (default `true`)
+- `runner` (default `local_subprocess`)
+- `python_executable` (default `python`)
+- `timeout_s` (default `20`)
+- `max_stdout_chars`, `max_stderr_chars`
+- `workspace_root`
+- `allow_network` (controls import-policy checks only; it is not runtime network isolation)
+- `allowed_imports`, `blocked_imports`
+- `max_artifacts`, `max_artifact_bytes`
+
+Sandbox limitations:
+- Runs Python only with a local subprocess runner.
+- Uses best-effort static policy checks; it is not a hardened sandbox for untrusted code.
+- Does not expose shell or bash execution.
+- Rejects blocked imports and known dangerous call patterns before execution.
+- Enforces timeout and output truncation.
+- Executes code in a temporary working directory and only returns files from that directory.
+
+Example config:
+
+```yaml
+tools:
+  - type: run_python
+    config:
+      runner: local_subprocess
+      timeout_s: 20
+      workspace_root: .
+      allow_network: false
+      blocked_imports:
+        - os
+        - subprocess
+        - socket
+        - requests
+        - urllib
+        - ctypes
+```
+
 ## Provider behavior
 
 - Search providers:

--- a/examples/run_python_demo.py
+++ b/examples/run_python_demo.py
@@ -1,0 +1,61 @@
+"""Run a simple run_python tool call from YAML/dict config."""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+from pathlib import Path
+
+from automa_ai.config.tools import ToolsConfig
+from automa_ai.tools import build_langchain_tools
+
+
+def _load_config(path: str | None) -> dict:
+    if path is None:
+        return {
+            "tools": [
+                {
+                    "type": "run_python",
+                    "config": {
+                        "runner": "local_subprocess",
+                        "timeout_s": 20,
+                    },
+                }
+            ]
+        }
+
+    p = Path(path)
+    text = p.read_text()
+    if p.suffix in {".yaml", ".yml"}:
+        import yaml  # optional
+
+        return yaml.safe_load(text)
+    return json.loads(text)
+
+
+async def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--code",
+        type=str,
+        default="print(sum(i * i for i in range(10)))",
+        help="Python code to execute.",
+    )
+    parser.add_argument("--config", type=str, default=None)
+    args = parser.parse_args()
+
+    config = ToolsConfig.from_dict(_load_config(args.config))
+    tools = build_langchain_tools(config.tools)
+    run_python = next((t for t in tools if t.name == "run_python"), None)
+    if run_python is None:
+        raise ValueError(
+            "No tool named 'run_python' was found. "
+            "Please ensure your tools configuration includes a 'run_python' tool."
+        )
+    out = await run_python.ainvoke({"code": args.code})
+    print(json.dumps(out, indent=2))
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -71,3 +71,4 @@ default_chroma = "automa_ai.memory.chroma_memory_store:ChromaVectorMemoryStore"
 
 [project.entry-points."automa_ai.tools"]
 web_search = "automa_ai.tools.web_search:build_web_search_tool"
+run_python = "automa_ai.tools.run_python:build_run_python_tool"

--- a/tests/test_run_python_tool.py
+++ b/tests/test_run_python_tool.py
@@ -1,0 +1,203 @@
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from automa_ai.config.tools import ToolSpec
+from automa_ai.tools import build_langchain_tools
+from automa_ai.tools.run_python.config import RunPythonToolConfig
+from automa_ai.tools.run_python.tool import RunPythonTool
+
+
+def test_registry_build_includes_run_python_and_web_search() -> None:
+    tools = build_langchain_tools(
+        [
+            ToolSpec(type="web_search", config={"provider": "opensource"}),
+            ToolSpec(type="run_python", config={}),
+        ]
+    )
+    names = {tool.name for tool in tools}
+    assert "web_search" in names
+    assert "run_python" in names
+
+
+@pytest.mark.asyncio
+async def test_run_python_happy_path_arithmetic() -> None:
+    tool = RunPythonTool(RunPythonToolConfig.model_validate({}))
+    result = await tool.invoke({"code": "print(sum(i*i for i in range(6)))"})
+
+    assert result["success"] is True
+    assert result["exit_code"] == 0
+    assert result["stdout"].strip() == "55"
+
+
+@pytest.mark.asyncio
+async def test_run_python_parses_json_and_csv(tmp_path) -> None:
+    json_path = tmp_path / "input.json"
+    csv_path = tmp_path / "input.csv"
+    json_path.write_text(json.dumps({"name": "demo", "value": 7}), encoding="utf-8")
+    csv_path.write_text("city,temp\nA,23\nB,19\n", encoding="utf-8")
+
+    tool = RunPythonTool(
+        RunPythonToolConfig.model_validate({"workspace_root": str(tmp_path)})
+    )
+    code = """
+import csv
+import json
+
+with open('input.json', 'r', encoding='utf-8') as f:
+    payload = json.load(f)
+
+with open('input.csv', 'r', encoding='utf-8') as f:
+    rows = list(csv.DictReader(f))
+
+print(payload['name'], payload['value'], len(rows))
+"""
+    result = await tool.invoke(
+        {
+            "code": code,
+            "input_files": ["input.json", "input.csv"],
+        }
+    )
+
+    assert result["success"] is True
+    assert result["stdout"].strip() == "demo 7 2"
+
+
+@pytest.mark.asyncio
+async def test_run_python_collects_artifact(tmp_path) -> None:
+    tool = RunPythonTool(
+        RunPythonToolConfig.model_validate({"workspace_root": str(tmp_path)})
+    )
+    code = """
+with open('table.csv', 'w', encoding='utf-8') as f:
+    f.write('x,y\\n1,2\\n3,4\\n')
+print('done')
+"""
+    result = await tool.invoke(
+        {
+            "code": code,
+            "expected_outputs": ["table.csv"],
+        }
+    )
+
+    assert result["success"] is True
+    assert result["artifacts"]
+    assert result["artifacts"][0]["path"] == "table.csv"
+
+
+@pytest.mark.asyncio
+async def test_run_python_policy_rejects_disallowed_import() -> None:
+    tool = RunPythonTool(RunPythonToolConfig.model_validate({}))
+    result = await tool.invoke({"code": "import subprocess\nprint('x')"})
+
+    assert result["success"] is False
+    assert "Blocked import" in result["stderr"]
+    assert "sandbox policy" in result["meta"]["warnings"][0].lower()
+
+
+@pytest.mark.asyncio
+async def test_run_python_does_not_return_copied_inputs_as_artifacts(tmp_path) -> None:
+    input_path = tmp_path / "input.txt"
+    input_path.write_text("seed", encoding="utf-8")
+
+    tool = RunPythonTool(
+        RunPythonToolConfig.model_validate({"workspace_root": str(tmp_path)})
+    )
+    result = await tool.invoke(
+        {
+            "code": "print(open('input.txt', encoding='utf-8').read())",
+            "input_files": ["input.txt"],
+        }
+    )
+
+    assert result["success"] is True
+    assert result["artifacts"] == []
+
+
+@pytest.mark.asyncio
+async def test_run_python_disables_artifact_collection_when_max_artifacts_zero(
+    tmp_path,
+) -> None:
+    tool = RunPythonTool(
+        RunPythonToolConfig.model_validate(
+            {"workspace_root": str(tmp_path), "max_artifacts": 0}
+        )
+    )
+    result = await tool.invoke(
+        {
+            "code": "open('result.txt', 'w', encoding='utf-8').write('ok')",
+        }
+    )
+
+    assert result["success"] is True
+    assert result["artifacts"] == []
+    assert all("Artifact limit reached" not in w for w in result["meta"]["warnings"])
+
+
+@pytest.mark.asyncio
+async def test_run_python_returns_only_generated_outputs_without_expected(tmp_path) -> None:
+    input_path = tmp_path / "input.txt"
+    input_path.write_text("seed", encoding="utf-8")
+
+    tool = RunPythonTool(
+        RunPythonToolConfig.model_validate({"workspace_root": str(tmp_path)})
+    )
+    result = await tool.invoke(
+        {
+            "code": "open('output.txt', 'w', encoding='utf-8').write('ok')",
+            "input_files": ["input.txt"],
+        }
+    )
+
+    assert result["success"] is True
+    assert [a["path"] for a in result["artifacts"]] == ["output.txt"]
+
+
+@pytest.mark.asyncio
+async def test_run_python_rejects_getattr_import_bypass() -> None:
+    tool = RunPythonTool(RunPythonToolConfig.model_validate({}))
+    result = await tool.invoke(
+        {"code": "getattr(__builtins__, '__import__')('os').system('echo unsafe')"}
+    )
+
+    assert result["success"] is False
+    assert "Blocked" in result["stderr"]
+
+
+@pytest.mark.asyncio
+async def test_run_python_invalid_input_file_returns_structured_error(tmp_path) -> None:
+    tool = RunPythonTool(
+        RunPythonToolConfig.model_validate({"workspace_root": str(tmp_path)})
+    )
+    result = await tool.invoke(
+        {
+            "code": "print('x')",
+            "input_files": ["../outside.txt"],
+        }
+    )
+
+    assert result["success"] is False
+    assert result["exit_code"] == 1
+    assert "workspace_root" in result["stderr"]
+    assert "before Python process start" in result["meta"]["warnings"][0]
+
+
+@pytest.mark.asyncio
+async def test_run_python_rejects_reserved_startup_filename(tmp_path) -> None:
+    reserved = tmp_path / "sitecustomize.py"
+    reserved.write_text("print('bad')", encoding="utf-8")
+
+    tool = RunPythonTool(
+        RunPythonToolConfig.model_validate({"workspace_root": str(tmp_path)})
+    )
+    result = await tool.invoke(
+        {
+            "code": "print('ok')",
+            "input_files": ["sitecustomize.py"],
+        }
+    )
+
+    assert result["success"] is False
+    assert "Reserved input filename" in result["stderr"]

--- a/tests/test_run_python_tool.py
+++ b/tests/test_run_python_tool.py
@@ -1,0 +1,97 @@
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from automa_ai.config.tools import ToolSpec
+from automa_ai.tools.registry import build_langchain_tools
+from automa_ai.tools.run_python.config import RunPythonToolConfig
+from automa_ai.tools.run_python.tool import RunPythonTool
+
+
+def test_registry_build_includes_run_python_and_web_search() -> None:
+    tools = build_langchain_tools(
+        [
+            ToolSpec(type="web_search", config={"provider": "opensource"}),
+            ToolSpec(type="run_python", config={}),
+        ]
+    )
+    names = {tool.name for tool in tools}
+    assert "web_search" in names
+    assert "run_python" in names
+
+
+@pytest.mark.asyncio
+async def test_run_python_happy_path_arithmetic() -> None:
+    tool = RunPythonTool(RunPythonToolConfig.model_validate({}))
+    result = await tool.invoke({"code": "print(sum(i*i for i in range(6)))"})
+
+    assert result["success"] is True
+    assert result["exit_code"] == 0
+    assert result["stdout"].strip() == "55"
+
+
+@pytest.mark.asyncio
+async def test_run_python_parses_json_and_csv(tmp_path) -> None:
+    json_path = tmp_path / "input.json"
+    csv_path = tmp_path / "input.csv"
+    json_path.write_text(json.dumps({"name": "demo", "value": 7}), encoding="utf-8")
+    csv_path.write_text("city,temp\nA,23\nB,19\n", encoding="utf-8")
+
+    tool = RunPythonTool(
+        RunPythonToolConfig.model_validate({"workspace_root": str(tmp_path)})
+    )
+    code = """
+import csv
+import json
+
+with open('input.json', 'r', encoding='utf-8') as f:
+    payload = json.load(f)
+
+with open('input.csv', 'r', encoding='utf-8') as f:
+    rows = list(csv.DictReader(f))
+
+print(payload['name'], payload['value'], len(rows))
+"""
+    result = await tool.invoke(
+        {
+            "code": code,
+            "input_files": ["input.json", "input.csv"],
+        }
+    )
+
+    assert result["success"] is True
+    assert result["stdout"].strip() == "demo 7 2"
+
+
+@pytest.mark.asyncio
+async def test_run_python_collects_artifact(tmp_path) -> None:
+    tool = RunPythonTool(
+        RunPythonToolConfig.model_validate({"workspace_root": str(tmp_path)})
+    )
+    code = """
+with open('table.csv', 'w', encoding='utf-8') as f:
+    f.write('x,y\\n1,2\\n3,4\\n')
+print('done')
+"""
+    result = await tool.invoke(
+        {
+            "code": code,
+            "expected_outputs": ["table.csv"],
+        }
+    )
+
+    assert result["success"] is True
+    assert result["artifacts"]
+    assert result["artifacts"][0]["path"] == "table.csv"
+
+
+@pytest.mark.asyncio
+async def test_run_python_policy_rejects_disallowed_import() -> None:
+    tool = RunPythonTool(RunPythonToolConfig.model_validate({}))
+    result = await tool.invoke({"code": "import subprocess\nprint('x')"})
+
+    assert result["success"] is False
+    assert "Blocked import" in result["stderr"]
+    assert "sandbox policy" in result["meta"]["warnings"][0].lower()

--- a/tests/test_run_python_tool.py
+++ b/tests/test_run_python_tool.py
@@ -5,7 +5,7 @@ import json
 import pytest
 
 from automa_ai.config.tools import ToolSpec
-from automa_ai.tools.registry import build_langchain_tools
+from automa_ai.tools import build_langchain_tools
 from automa_ai.tools.run_python.config import RunPythonToolConfig
 from automa_ai.tools.run_python.tool import RunPythonTool
 
@@ -95,3 +95,42 @@ async def test_run_python_policy_rejects_disallowed_import() -> None:
     assert result["success"] is False
     assert "Blocked import" in result["stderr"]
     assert "sandbox policy" in result["meta"]["warnings"][0].lower()
+
+
+@pytest.mark.asyncio
+async def test_run_python_does_not_return_copied_inputs_as_artifacts(tmp_path) -> None:
+    input_path = tmp_path / "input.txt"
+    input_path.write_text("seed", encoding="utf-8")
+
+    tool = RunPythonTool(
+        RunPythonToolConfig.model_validate({"workspace_root": str(tmp_path)})
+    )
+    result = await tool.invoke(
+        {
+            "code": "print(open('input.txt', encoding='utf-8').read())",
+            "input_files": ["input.txt"],
+        }
+    )
+
+    assert result["success"] is True
+    assert result["artifacts"] == []
+
+
+@pytest.mark.asyncio
+async def test_run_python_disables_artifact_collection_when_max_artifacts_zero(
+    tmp_path,
+) -> None:
+    tool = RunPythonTool(
+        RunPythonToolConfig.model_validate(
+            {"workspace_root": str(tmp_path), "max_artifacts": 0}
+        )
+    )
+    result = await tool.invoke(
+        {
+            "code": "open('result.txt', 'w', encoding='utf-8').write('ok')",
+        }
+    )
+
+    assert result["success"] is True
+    assert result["artifacts"] == []
+    assert all("Artifact limit reached" not in w for w in result["meta"]["warnings"])

--- a/tests/test_run_python_tool.py
+++ b/tests/test_run_python_tool.py
@@ -1,0 +1,184 @@
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from automa_ai.config.tools import ToolSpec
+from automa_ai.tools import build_langchain_tools
+from automa_ai.tools.run_python.config import RunPythonToolConfig
+from automa_ai.tools.run_python.tool import RunPythonTool
+
+
+def test_registry_build_includes_run_python_and_web_search() -> None:
+    tools = build_langchain_tools(
+        [
+            ToolSpec(type="web_search", config={"provider": "opensource"}),
+            ToolSpec(type="run_python", config={}),
+        ]
+    )
+    names = {tool.name for tool in tools}
+    assert "web_search" in names
+    assert "run_python" in names
+
+
+@pytest.mark.asyncio
+async def test_run_python_happy_path_arithmetic() -> None:
+    tool = RunPythonTool(RunPythonToolConfig.model_validate({}))
+    result = await tool.invoke({"code": "print(sum(i*i for i in range(6)))"})
+
+    assert result["success"] is True
+    assert result["exit_code"] == 0
+    assert result["stdout"].strip() == "55"
+
+
+@pytest.mark.asyncio
+async def test_run_python_parses_json_and_csv(tmp_path) -> None:
+    json_path = tmp_path / "input.json"
+    csv_path = tmp_path / "input.csv"
+    json_path.write_text(json.dumps({"name": "demo", "value": 7}), encoding="utf-8")
+    csv_path.write_text("city,temp\nA,23\nB,19\n", encoding="utf-8")
+
+    tool = RunPythonTool(
+        RunPythonToolConfig.model_validate({"workspace_root": str(tmp_path)})
+    )
+    code = """
+import csv
+import json
+
+with open('input.json', 'r', encoding='utf-8') as f:
+    payload = json.load(f)
+
+with open('input.csv', 'r', encoding='utf-8') as f:
+    rows = list(csv.DictReader(f))
+
+print(payload['name'], payload['value'], len(rows))
+"""
+    result = await tool.invoke(
+        {
+            "code": code,
+            "input_files": ["input.json", "input.csv"],
+        }
+    )
+
+    assert result["success"] is True
+    assert result["stdout"].strip() == "demo 7 2"
+
+
+@pytest.mark.asyncio
+async def test_run_python_collects_artifact(tmp_path) -> None:
+    tool = RunPythonTool(
+        RunPythonToolConfig.model_validate({"workspace_root": str(tmp_path)})
+    )
+    code = """
+with open('table.csv', 'w', encoding='utf-8') as f:
+    f.write('x,y\\n1,2\\n3,4\\n')
+print('done')
+"""
+    result = await tool.invoke(
+        {
+            "code": code,
+            "expected_outputs": ["table.csv"],
+        }
+    )
+
+    assert result["success"] is True
+    assert result["artifacts"]
+    assert result["artifacts"][0]["path"] == "table.csv"
+
+
+@pytest.mark.asyncio
+async def test_run_python_policy_rejects_disallowed_import() -> None:
+    tool = RunPythonTool(RunPythonToolConfig.model_validate({}))
+    result = await tool.invoke({"code": "import subprocess\nprint('x')"})
+
+    assert result["success"] is False
+    assert "Blocked import" in result["stderr"]
+    assert "sandbox policy" in result["meta"]["warnings"][0].lower()
+
+
+@pytest.mark.asyncio
+async def test_run_python_does_not_return_copied_inputs_as_artifacts(tmp_path) -> None:
+    input_path = tmp_path / "input.txt"
+    input_path.write_text("seed", encoding="utf-8")
+
+    tool = RunPythonTool(
+        RunPythonToolConfig.model_validate({"workspace_root": str(tmp_path)})
+    )
+    result = await tool.invoke(
+        {
+            "code": "print(open('input.txt', encoding='utf-8').read())",
+            "input_files": ["input.txt"],
+        }
+    )
+
+    assert result["success"] is True
+    assert result["artifacts"] == []
+
+
+@pytest.mark.asyncio
+async def test_run_python_disables_artifact_collection_when_max_artifacts_zero(
+    tmp_path,
+) -> None:
+    tool = RunPythonTool(
+        RunPythonToolConfig.model_validate(
+            {"workspace_root": str(tmp_path), "max_artifacts": 0}
+        )
+    )
+    result = await tool.invoke(
+        {
+            "code": "open('result.txt', 'w', encoding='utf-8').write('ok')",
+        }
+    )
+
+    assert result["success"] is True
+    assert result["artifacts"] == []
+    assert all("Artifact limit reached" not in w for w in result["meta"]["warnings"])
+
+
+@pytest.mark.asyncio
+async def test_run_python_returns_only_generated_outputs_without_expected(tmp_path) -> None:
+    input_path = tmp_path / "input.txt"
+    input_path.write_text("seed", encoding="utf-8")
+
+    tool = RunPythonTool(
+        RunPythonToolConfig.model_validate({"workspace_root": str(tmp_path)})
+    )
+    result = await tool.invoke(
+        {
+            "code": "open('output.txt', 'w', encoding='utf-8').write('ok')",
+            "input_files": ["input.txt"],
+        }
+    )
+
+    assert result["success"] is True
+    assert [a["path"] for a in result["artifacts"]] == ["output.txt"]
+
+
+@pytest.mark.asyncio
+async def test_run_python_rejects_getattr_import_bypass() -> None:
+    tool = RunPythonTool(RunPythonToolConfig.model_validate({}))
+    result = await tool.invoke(
+        {"code": "getattr(__builtins__, '__import__')('os').system('echo unsafe')"}
+    )
+
+    assert result["success"] is False
+    assert "Blocked" in result["stderr"]
+
+
+@pytest.mark.asyncio
+async def test_run_python_invalid_input_file_returns_structured_error(tmp_path) -> None:
+    tool = RunPythonTool(
+        RunPythonToolConfig.model_validate({"workspace_root": str(tmp_path)})
+    )
+    result = await tool.invoke(
+        {
+            "code": "print('x')",
+            "input_files": ["../outside.txt"],
+        }
+    )
+
+    assert result["success"] is False
+    assert result["exit_code"] == 1
+    assert "workspace_root" in result["stderr"]
+    assert "before Python process start" in result["meta"]["warnings"][0]


### PR DESCRIPTION
### Motivation

- Provide a first-class built-in `run_python` default tool for calculations, parsing, table/chart creation, file transformations, and simulation preparation while preserving the existing default-tool registry and interfaces. 
- Implement a practical sandbox to prevent shell access and obviously dangerous imports/patterns while enabling common data-processing workflows.

### Description

- Added a new tool package `automa_ai/tools/run_python/` containing `config.py`, `policy.py`, `runner.py`, `tool.py`, and `__init__.py` implementing a `RunPythonTool` compatible with `BaseDefaultTool` and a `build_run_python_tool(...)` builder for the registry. 
- Implemented a lightweight static policy (`policy.py`) that rejects blocked imports and dangerous call patterns and a `LocalSubprocessRunner` (`runner.py`) that runs code in a temporary workspace using a subprocess, enforces timeouts, truncates outputs, and collects artifacts. 
- Registered the new tool alongside `web_search` in `automa_ai/tools/__init__.py` without changing `ToolSpec`, `ToolsConfig`, `BaseDefaultTool`, or `build_langchain_tools`. 
- Added `examples/run_python_demo.py` modeled on the existing default-tool demo, added tests in `tests/test_run_python_tool.py`, and updated `docs/tools.md` and `README.md` to document config, contract, and sandbox limitations.

### Testing

- Compiled the new module tree with `python -m compileall ...` and it succeeded (modules compile cleanly). 
- Ran `pytest tests/test_run_python_tool.py tests/test_tools_config.py tests/test_web_search_tool.py -q` but collection failed due to `ModuleNotFoundError: No module named 'pydantic'` in the environment, causing the test run to fail. 
- Attempted to install `pydantic` via `python -m pip install pydantic` but the environment could not download packages due to proxy/network restrictions, so unit tests could not be executed to completion here. 

Notes: the patch adds unit tests that cover registry/build integration, arithmetic execution, JSON/CSV parsing, artifact generation, and sandbox rejection; these should pass in a normal environment with dependencies installed and are expected to be green in CI where `pydantic` and test dependencies are available. There are no breaking changes to existing tool interfaces.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ad4406fd2083318ca55a141aabc402)