### PR TITLE
Remove `enabled` toggle from run_python tool config and docs

### DIFF
--- a/automa_ai/tools/run_python/config.py
+++ b/automa_ai/tools/run_python/config.py
@@ -8,7 +8,6 @@ from pydantic import BaseModel, Field
 class RunPythonToolConfig(BaseModel):
     """Runtime configuration for the Python execution tool."""
 
-    enabled: bool = True
     runner: str = "local_subprocess"
     python_executable: str = "python"
     timeout_s: int = Field(default=20, ge=1, le=300)

--- a/automa_ai/tools/run_python/tool.py
+++ b/automa_ai/tools/run_python/tool.py
@@ -95,8 +95,6 @@ class RunPythonTool(BaseDefaultTool):
 
 def build_run_python_tool(config: dict[str, Any], _runtime_deps: Any) -> RunPythonTool:
     parsed = RunPythonToolConfig.model_validate(config)
-    if not parsed.enabled:
-        raise ValueError("run_python tool is disabled by configuration.")
     if parsed.runner != "local_subprocess":
         raise ValueError(f"Unsupported run_python runner: {parsed.runner}")
     return RunPythonTool(parsed)

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -57,7 +57,6 @@ Output format:
 - `meta`: `{runner, warnings}`
 
 Configuration fields:
-- `enabled` (default `true`)
 - `runner` (default `local_subprocess`)
 - `python_executable` (default `python`)
 - `timeout_s` (default `20`)


### PR DESCRIPTION
### Motivation
- Simplify the `run_python` tool configuration by removing the `enabled` toggle so the tool is always constructible through configuration parsing.
- Keep documentation in sync with the code by removing the now-unused `enabled` entry from the `run_python` section in the tools docs.

### Description
- Remove the `enabled` field from `RunPythonToolConfig` in `automa_ai/tools/run_python/config.py` and its default.
- Remove the runtime check in `build_run_python_tool` that raised a `ValueError` when `parsed.enabled` was false in `automa_ai/tools/run_python/tool.py`.
- Update `docs/tools.md` to remove the `enabled` configuration line from the `run_python` built-in tool documentation.

### Testing
- Ran unit tests with `pytest` which completed successfully.
- Built the docs with `mkdocs build` which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69df202ae72883319f95a48259e4f5f1)