### PR TITLE
Add decorator to create custom local tools

### DIFF
--- a/automa_ai/tools/__init__.py
+++ b/automa_ai/tools/__init__.py
@@ -1,6 +1,11 @@
 """Built-in default tools registry."""
 
-from automa_ai.tools.registry import DEFAULT_TOOL_REGISTRY, build_langchain_tools
+from automa_ai.tools.registry import (
+    DEFAULT_TOOL_REGISTRY,
+    CUSTOM_TOOL_REGISTRY,
+    build_langchain_tools,
+)
+from automa_ai.tools.decorators import tool
 from automa_ai.tools.run_python import build_run_python_tool
 from automa_ai.tools.web_search import build_web_search_tool
 
@@ -14,12 +19,9 @@ except ValueError as exc:
         exc,
     )
 
-try:
-    DEFAULT_TOOL_REGISTRY.register("run_python", build_run_python_tool)
-except ValueError as exc:
-    logging.getLogger(__name__).debug(
-        "Ignoring ValueError while registering 'run_python' tool: %s",
-        exc,
-    )
-
-__all__ = ["DEFAULT_TOOL_REGISTRY", "build_langchain_tools"]
+__all__ = [
+    "DEFAULT_TOOL_REGISTRY",
+    "CUSTOM_TOOL_REGISTRY",
+    "build_langchain_tools",
+    "tool",
+]

--- a/automa_ai/tools/base.py
+++ b/automa_ai/tools/base.py
@@ -18,6 +18,7 @@ class BaseDefaultTool(abc.ABC):
     """Internal interface for default tools configured by users."""
 
     type: str
+    name: str | None = None
 
     @property
     @abc.abstractmethod
@@ -41,7 +42,7 @@ class BaseDefaultTool(abc.ABC):
             return await self.invoke(kwargs)
 
         return StructuredTool.from_function(
-            name=self.type,
+            name=self.name or self.type,
             description=self.description,
             args_schema=self.args_schema,
             coroutine=_arun,

--- a/automa_ai/tools/decorators.py
+++ b/automa_ai/tools/decorators.py
@@ -1,0 +1,200 @@
+from __future__ import annotations
+
+import functools
+import inspect
+from typing import Any, Callable
+
+from langchain_core.tools import StructuredTool
+from pydantic import BaseModel
+
+from automa_ai.tools.base import BaseDefaultTool, RuntimeDeps
+from automa_ai.tools.registry import CUSTOM_TOOL_REGISTRY
+
+
+def _without_param(fn: Callable, param_name: str) -> Callable:
+    """
+    Return a wrapper around `fn` whose public signature omits `param_name`.
+
+    The wrapper is NOT meant to be called directly (the hidden param would be
+    missing). It exists purely so schema-introspection tools (LangChain,
+    Pydantic, etc.) don't see `param_name`.
+
+    Preserves:
+      - name, docstring, module
+      - async-ness (returns async wrapper for async fn)
+      - remaining parameter annotations and defaults
+      - return annotation
+    """
+    sig = inspect.signature(fn)
+    if param_name not in sig.parameters:
+        raise ValueError(
+            f"{fn.__qualname__} has no parameter named {param_name}"
+        )
+
+    new_params = [p for name, p in sig.parameters.items() if name != param_name]
+    new_sig = sig.replace(parameters=new_params)
+
+    # Build a clean __annotations__ dict (drop the hidden param, keep 'return')
+    new_annotations = {
+        k: v for k, v in getattr(fn, "__annotations__", {}).items()
+        if k != param_name
+    }
+
+    if inspect.iscoroutinefunction(fn):
+        @functools.wraps(fn)
+        async def wrapper(*args, **kwargs):
+            raise RuntimeError(
+                f"{fn.__qualname__}: schema-only wrapper called directly; "
+                f"parameter {param_name} is injected by the framework."
+            )
+    else:
+        @functools.wraps(fn)
+        def wrapper(*args, **kwargs):
+            raise RuntimeError(
+                f"{fn.__qualname__}: schema-only wrapper called directly; "
+                f"parameter {param_name} is injected by the framework."
+            )
+
+    wrapper.__signature__ = new_sig
+    wrapper.__annotations__ = new_annotations
+    return wrapper
+
+def tool(
+    func: Callable | None = None,
+    *,
+    name: str | None = None,
+    description: str | None = None,
+    parse_docstring: bool = True,
+    config_schema: type[BaseModel] | None = None,
+):
+    """
+    Register a function as a custom tool. Supports config injection.
+
+    Usage:
+        # Simple (no config needed):
+        @tool
+        def my_tool(text: str, count: int = 1) -> str:
+            '''Repeat text.
+
+            Args:
+                text: Text to repeat
+                count: Number of times
+            '''
+            return text * count
+
+        # With config:
+        class MyConfig(BaseModel):
+            api_key: str
+
+        @tool(config_schema=MyConfig)
+        def my_tool(query: str, *, config: MyConfig) -> dict:
+            '''Search with API.
+
+            Args:
+                query: Search query
+            '''
+            return {"results": search(query, config.api_key)}
+
+    Args:
+        func: Function to convert to a tool
+        name: Optional display name shown to the LLM. Does NOT affect how the
+              tool is referenced in configuration — tools are always registered
+              and looked up by their fully qualified name (`module.function`).
+        description: Optional description override
+        parse_docstring: Whether to parse Google-style docstrings
+        config_schema: Optional Pydantic model for configuration validation
+
+    Returns:
+        The original function (unmodified)
+    """
+    def decorator(fn: Callable) -> Callable:
+        sig = inspect.signature(fn)
+        is_async = inspect.iscoroutinefunction(fn)
+
+        has_config_schema = config_schema is not None
+        has_config_param = "config" in sig.parameters
+
+        # Validate config_schema and config parameter match
+        if has_config_schema != has_config_param:
+            if has_config_schema:
+                raise TypeError(
+                    f"{fn.__qualname__}: config_schema provided but function has "
+                    f"no 'config' parameter"
+                )
+            else:
+                raise TypeError(
+                    f"{fn.__qualname__}: function declares a 'config' parameter but "
+                    f"no config_schema was provided to @tool"
+                )
+            
+        # Hide 'config' from LLM schema if present
+        schema_fn = _without_param(fn, "config") if has_config_param else fn
+
+        tool_name = name or fn.__name__
+
+        # Create LangChain tool using StructuredTool.from_function
+        langchain_tool = StructuredTool.from_function(
+            func=None if is_async else schema_fn,
+            coroutine=schema_fn if is_async else None,
+            name=tool_name,
+            description=description,
+            parse_docstring=parse_docstring,
+            infer_schema=True,
+        )
+
+        fq_name = f"{fn.__module__}.{fn.__name__}"
+
+        class Wrapper(BaseDefaultTool):
+            type: str = fq_name
+            name: str = tool_name
+
+            def __init__(self, config: dict, runtime_deps: RuntimeDeps):
+                self._config = config
+                self._runtime_deps = runtime_deps
+                self._langchain_tool = langchain_tool
+
+                if config_schema:
+                    self._validated_config = config_schema.model_validate(config)
+                else:
+                    self._validated_config = None
+
+            @property
+            def args_schema(self) -> type[BaseModel]:
+                return self._langchain_tool.args_schema
+
+            @property
+            def description(self) -> str:
+                return self._langchain_tool.description
+
+            async def invoke(self, payload: dict[str, Any]) -> dict[str, Any]:
+                # If function needs config, inject it and call directly
+                if has_config_param:
+                    validated = self._langchain_tool.args_schema.model_validate(payload)
+                    kwargs = {**validated.model_dump(), "config": self._validated_config}
+                    result = await fn(**kwargs) if is_async else fn(**kwargs)
+                else:
+                    # Use LangChain's tool execution (handles sync/async)
+                    result = await self._langchain_tool.ainvoke(payload)
+
+                # Normalize to dict
+                if isinstance(result, BaseModel):
+                    return result.model_dump(mode="json")
+                if not isinstance(result, dict):
+                    return {"result": result}
+                return result
+            
+        # Register builder
+        def builder(config: dict[str, Any], runtime_deps: RuntimeDeps) -> BaseDefaultTool:
+            return Wrapper(config, runtime_deps)
+
+
+        CUSTOM_TOOL_REGISTRY.register(fq_name, builder)
+
+        setattr(fn, "__tool_name__", tool_name)
+
+        return fn
+
+    # Support both @tool and @tool(...)
+    if func is not None:
+        return decorator(func)
+    return decorator

--- a/automa_ai/tools/registry.py
+++ b/automa_ai/tools/registry.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import importlib
 import logging
 from collections.abc import Callable
 from typing import Any
@@ -23,27 +24,69 @@ class ToolRegistry:
             raise ValueError(f"Tool type '{tool_type}' is already registered.")
         self._builders[tool_type] = builder
 
-    def build(self, spec: ToolSpec, runtime_deps: RuntimeDeps) -> BaseDefaultTool:
-        if spec.type not in self._builders:
-            raise ValueError(f"Unknown tool type '{spec.type}'.")
-        return self._builders[spec.type](spec.config, runtime_deps)
+    def build(self, spec: ToolSpec, runtime_deps: RuntimeDeps | None = None) -> BaseDefaultTool:
+        tool_type = spec.type
+
+        # Use default runtime deps if not provided
+        if runtime_deps is None:
+            runtime_deps = RuntimeDeps()
+
+        # Auto-import if type contains dots (e.g., "mydir.tools.my_tool")
+        if tool_type not in self._builders and "." in tool_type:
+            self._try_auto_import(tool_type)
+
+        if tool_type not in self._builders:
+            raise ValueError(
+                f"Unknown tool type '{tool_type}'. "
+                f"Known tools: {sorted(self._builders)}"
+            )
+
+        return self._builders[tool_type](spec.config, runtime_deps)
+
+    def _try_auto_import(self, tool_type: str) -> None:
+        """Try importing module from dotted tool type.
+        """
+        parts = tool_type.rsplit(".", 1)
+        if len(parts) != 2:
+            return
+        
+        module_path, _ = parts
+        
+        try:
+            importlib.import_module(module_path)
+        except ModuleNotFoundError as e:
+            if e.name != module_path:
+                raise
+            return
 
 
 DEFAULT_TOOL_REGISTRY = ToolRegistry()
+CUSTOM_TOOL_REGISTRY = ToolRegistry()
 
 
 def build_langchain_tools(
     tool_specs: list[ToolSpec] | None, logger: logging.Logger | None = None
 ) -> list[Any]:
-    """Build configured tools and adapt them for LangChain."""
+    """Build configured tools and adapt them for LangChain.
+
+    Checks both DEFAULT_TOOL_REGISTRY (built-in tools) and CUSTOM_TOOL_REGISTRY
+    (user-defined @tool decorated functions). For custom tools, supports auto-import
+    via dotted paths (e.g., "mydir.tools.my_tool").
+    """
     if not tool_specs:
         return []
+
     runtime_deps = RuntimeDeps(
         logger_name=(logger.name if logger else "automa_ai.tools")
     )
     built: list[Any] = []
     for spec in tool_specs:
-        built.append(
-            DEFAULT_TOOL_REGISTRY.build(spec, runtime_deps).as_langchain_tool()
-        )
+        # Try DEFAULT_TOOL_REGISTRY first (built-ins like web_search)
+        try:
+            tool = DEFAULT_TOOL_REGISTRY.build(spec, runtime_deps)
+        except ValueError:
+            # Fall back to CUSTOM_TOOL_REGISTRY (user @tool decorators)
+            tool = CUSTOM_TOOL_REGISTRY.build(spec, runtime_deps)
+
+        built.append(tool.as_langchain_tool())
     return built

--- a/automa_ai/tools/registry.py
+++ b/automa_ai/tools/registry.py
@@ -13,6 +13,9 @@ from automa_ai.tools.base import BaseDefaultTool, RuntimeDeps
 ToolBuilder = Callable[[dict[str, Any], RuntimeDeps], BaseDefaultTool]
 
 
+class ToolNotFoundError(ValueError):
+    pass
+
 class ToolRegistry:
     """Maps tool type to a builder implementation."""
 
@@ -20,8 +23,13 @@ class ToolRegistry:
         self._builders: dict[str, ToolBuilder] = {}
 
     def register(self, tool_type: str, builder: ToolBuilder) -> None:
-        if tool_type in self._builders:
+        if (
+            tool_type in self._builders 
+            or tool_type in DEFAULT_TOOL_REGISTRY._builders 
+            or tool_type in CUSTOM_TOOL_REGISTRY._builders
+        ):
             raise ValueError(f"Tool type '{tool_type}' is already registered.")
+        
         self._builders[tool_type] = builder
 
     def build(self, spec: ToolSpec, runtime_deps: RuntimeDeps | None = None) -> BaseDefaultTool:
@@ -36,7 +44,7 @@ class ToolRegistry:
             self._try_auto_import(tool_type)
 
         if tool_type not in self._builders:
-            raise ValueError(
+            raise ToolNotFoundError(
                 f"Unknown tool type '{tool_type}'. "
                 f"Known tools: {sorted(self._builders)}"
             )
@@ -52,12 +60,7 @@ class ToolRegistry:
         
         module_path, _ = parts
         
-        try:
-            importlib.import_module(module_path)
-        except ModuleNotFoundError as e:
-            if e.name != module_path:
-                raise
-            return
+        importlib.import_module(module_path)
 
 
 DEFAULT_TOOL_REGISTRY = ToolRegistry()
@@ -84,8 +87,8 @@ def build_langchain_tools(
         # Try DEFAULT_TOOL_REGISTRY first (built-ins like web_search)
         try:
             tool = DEFAULT_TOOL_REGISTRY.build(spec, runtime_deps)
-        except ValueError:
-            # Fall back to CUSTOM_TOOL_REGISTRY (user @tool decorators)
+        except ToolNotFoundError:
+            # Fall back to CUSTOM_TOOL_REGISTRY
             tool = CUSTOM_TOOL_REGISTRY.build(spec, runtime_deps)
 
         built.append(tool.as_langchain_tool())

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -1,6 +1,8 @@
-# Default tools
+# Tools
 
-Automa-AI supports first-class default tools configured directly in agent config (not MCP).
+Automa-AI supports two types of tools:
+1. **Built-in tools** - Framework-provided tools like `web_search`
+2. **Custom tools** - User-defined tools using `@tool` decorator
 
 ## Configuration format
 
@@ -117,3 +119,100 @@ Optional local embedding rerank helpers:
 ```bash
 pip install -e .[rerank]
 ```
+
+---
+
+## Custom Tools
+
+Define your own tools using the `@tool` decorator. Tools are automatically registered and can be used in agent config.
+
+### Basic usage
+
+```python
+# myapp/tools.py
+from automa_ai.tools import tool
+
+@tool
+def repeat_text(text: str, count: int = 1) -> str:
+    """Repeat text multiple times.
+    
+    Args:
+        text: Text to repeat
+        count: Number of times
+    """
+    return text * count
+```
+
+Reference in config using dotted path:
+
+```yaml
+tools:
+  - type: myapp.tools.repeat_text
+    config: {}
+```
+
+The framework will auto-import `myapp.tools`, triggering the decorator and registering the tool.
+
+### Async tools
+
+```python
+@tool
+async def fetch_data(url: str) -> dict:
+    """Fetch data from URL.
+    
+    Args:
+        url: URL to fetch
+    """
+    async with httpx.AsyncClient() as client:
+        response = await client.get(url)
+        return {"data": response.json()}
+```
+
+### Tools with configuration
+
+For tools requiring API keys or settings:
+
+```python
+from pydantic import BaseModel
+
+class SearchConfig(BaseModel):
+    api_key: str
+    endpoint: str = "https://api.example.com"
+
+@tool(config_schema=SearchConfig)
+def search(query: str, *, config: SearchConfig) -> dict:
+    """Search using configured API.
+    
+    Args:
+        query: Search query
+    """
+    # Config is injected automatically
+    return call_api(query, config.api_key, config.endpoint)
+```
+
+Config in YAML:
+
+```yaml
+tools:
+  - type: myapp.tools.search
+    config:
+      api_key: ${SEARCH_API_KEY}
+      endpoint: "https://custom.api.com"
+```
+
+### Custom name and description
+
+```python
+@tool(name="web_search", description="Search the web")
+def my_search_tool(query: str) -> dict:
+    """This docstring is overridden by description parameter."""
+    return {"results": [...]}
+```
+
+### Features
+
+- **Schema inference**: Automatically generates Pydantic schemas from type hints
+- **Docstring parsing**: Extracts parameter descriptions from Google-style docstrings
+- **Config injection**: Pass configuration at instantiation time
+- **Auto-import**: Tools are imported automatically based on config `type` field
+- **Sync/async**: Both sync and async functions supported

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -4,6 +4,8 @@ Automa-AI supports two types of tools:
 1. **Built-in tools** - Framework-provided tools like `web_search`
 2. **Custom tools** - User-defined tools using `@tool` decorator
 
+> **Important:** Built-in tools are **not automatically available**. They, along with custom tools, must be explicitly enabled by the user through `tools_config`. If a tool is not included in the configuration, the agent will not be able to use it.
+
 ## Configuration format
 
 ```yaml
@@ -32,6 +34,8 @@ tools:
 
 ## Built-in tool: `web_search`
 
+> ⚠️ This tool must be explicitly enabled in `tools_config` to be used.
+
 Input fields:
 - `query` (required)
 - `top_k` (default `5`)
@@ -46,6 +50,8 @@ Output format:
 
 
 ## Built-in tool: `run_python`
+
+> ⚠️ This tool must be explicitly enabled in `tools_config` to be used.
 
 Input fields:
 - `code` (required)

--- a/examples/custom_tool_demo.py
+++ b/examples/custom_tool_demo.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import asyncio
 import os
 import math
-from automa_ai.tools.decorators import tool
+from automa_ai.tools import tool
 
 from a2a.types import AgentCard, AgentCapabilities
 

--- a/examples/custom_tool_demo.py
+++ b/examples/custom_tool_demo.py
@@ -1,0 +1,93 @@
+from __future__ import annotations
+
+import asyncio
+import os
+import math
+from automa_ai.tools.decorators import tool
+
+from a2a.types import AgentCard, AgentCapabilities
+
+from automa_ai.agents import GenericAgentType, GenericLLM
+from automa_ai.agents.agent_factory import AgentFactory
+from automa_ai.common.agent_registry import A2AAgentServer, A2AServerManager
+
+
+@tool(name="compute_factorial")
+def factorial(n: int) -> dict:
+    """Compute the factorial of a non-negative integer n."""
+    if n < 0:
+        return {"error": "ValueError", "message": "n must be non-negative"}
+    if n > 1000:
+        return {"error": "ValueError", "message": "n too large (max 1000)"}
+    return {"n": n, "result": str(math.factorial(n))}
+
+ARITHMETIC_COT = """
+You are a precise factorial calculator assistant. 
+Do not attempt mental math, only use the factorial tool provided.
+"""
+
+AGENT_URL = "http://localhost:31000"
+MODEL_NAME = "llama3.1:8b"
+MODEL_BASE_URL = os.getenv("OLLAMA_HOST", "http://localhost:11434")
+
+tools_config = {
+    "tools": [
+        {"type": f"examples.custom_tool_demo.factorial"},
+    ]
+}
+
+public_agent_card = AgentCard(
+    name="Arithmetic Agent",
+    description="An agent that performs exact arithmetic via calculator tools.",
+    url=AGENT_URL,
+    version="1.0.0",
+    default_input_modes=["text"],
+    default_output_modes=["text"],
+    supports_authenticated_extended_card=False,
+    skills=[],
+    capabilities=AgentCapabilities(streaming=True),
+)
+
+
+arithmetic_agent = AgentFactory(
+    card=public_agent_card,
+    instructions=ARITHMETIC_COT,
+    model_name=MODEL_NAME,
+    agent_type=GenericAgentType.LANGGRAPHCHAT,
+    chat_model=GenericLLM.OLLAMA,
+    model_base_url=MODEL_BASE_URL,
+    tools_config=tools_config,
+    enable_metrics=True,
+    debug=True,
+
+)
+
+arithmetic_a2a = A2AAgentServer(arithmetic_agent, public_agent_card)
+
+server_manager = A2AServerManager()
+server_manager.add_server(arithmetic_a2a)
+
+
+async def main():
+    await server_manager.start_all()
+    print(f"✅ Arithmetic Agent started at {AGENT_URL}")
+    print("Type 'exit' or 'stop' to shut down.")
+
+    loop = asyncio.get_event_loop()
+    stop_event = asyncio.Event()
+
+    async def wait_for_input():
+        while True:
+            cmd = await loop.run_in_executor(None, input, "> ")
+            if cmd.strip().lower() in {"exit", "stop", "quit"}:
+                stop_event.set()
+                break
+
+    await wait_for_input()
+    print("🛑 Stopping server...")
+    await server_manager.stop_all()
+    print("🧹 Server stopped cleanly.")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/tests/test_tool_decorator.py
+++ b/tests/test_tool_decorator.py
@@ -22,8 +22,6 @@ def test_tool_with_custom_name():
     def original_name(x: int) -> int:
         """Tool with custom name."""
         return x * 2
-    
-    print(original_name.__name__)
 
     assert original_name.__tool_name__ == f"custom_name"
     assert f"{__name__}.{original_name.__name__}" in CUSTOM_TOOL_REGISTRY._builders

--- a/tests/test_tool_decorator.py
+++ b/tests/test_tool_decorator.py
@@ -1,0 +1,140 @@
+import pytest
+from pydantic import BaseModel
+
+from automa_ai.tools import tool
+from automa_ai.tools.registry import CUSTOM_TOOL_REGISTRY, build_langchain_tools
+from automa_ai.config.tools import ToolSpec
+
+def test_simple_tool_registration():
+    """Test that @tool decorator registers tools."""
+    @tool
+    def test_tool(text: str) -> str:
+        """Test tool."""
+        return text.upper()
+
+    assert test_tool.__tool_name__ == "test_tool"
+    assert f"{__name__}.{test_tool.__name__}" in CUSTOM_TOOL_REGISTRY._builders
+
+
+def test_tool_with_custom_name():
+    """Test @tool with custom name."""
+    @tool(name="custom_name")
+    def original_name(x: int) -> int:
+        """Tool with custom name."""
+        return x * 2
+    
+    print(original_name.__name__)
+
+    assert original_name.__tool_name__ == f"custom_name"
+    assert f"{__name__}.{original_name.__name__}" in CUSTOM_TOOL_REGISTRY._builders
+
+
+def test_tool_with_config_schema():
+    """Test @tool with config schema."""
+    class MyConfig(BaseModel):
+        api_key: str
+        timeout: int = 30
+
+    @tool(config_schema=MyConfig)
+    def configured_tool(query: str, *, config: MyConfig) -> dict:
+        """Tool that requires config."""
+        return {"query": query, "api_key": config.api_key}
+
+    assert f"{__name__}.configured_tool" in CUSTOM_TOOL_REGISTRY._builders
+
+
+@pytest.mark.asyncio
+async def test_async_tool():
+    """Test async tool invocation."""
+    @tool
+    async def async_tool(value: str) -> dict:
+        """Async test tool."""
+        return {"result": value}
+
+    spec = ToolSpec(type=f"{__name__}.async_tool")
+    built_tool = CUSTOM_TOOL_REGISTRY.build(spec)
+
+    result = await built_tool.invoke({"value": "test"})
+    assert result == {"result": "test"}
+
+
+@pytest.mark.asyncio
+async def test_sync_tool():
+    """Test sync tool invocation."""
+    @tool
+    def sync_tool(x: int, y: int) -> dict:
+        """Sync test tool."""
+        return {"sum": x + y}
+
+    spec = ToolSpec(type=f"{__name__}.sync_tool")
+    built_tool = CUSTOM_TOOL_REGISTRY.build(spec)
+
+    result = await built_tool.invoke({"x": 5, "y": 3})
+    assert result == {"sum": 8}
+
+
+@pytest.mark.asyncio
+async def test_tool_with_config_injection():
+    """Test that config is properly injected."""
+    class ApiConfig(BaseModel):
+        api_key: str
+
+    @tool(config_schema=ApiConfig)
+    def api_tool(query: str, *, config: ApiConfig) -> dict:
+        """Tool using config."""
+        return {"query": query, "key": config.api_key}
+
+    spec = ToolSpec(type=f"{__name__}.api_tool", config={"api_key": "secret123"})
+    built_tool = CUSTOM_TOOL_REGISTRY.build(spec)
+
+    result = await built_tool.invoke({"query": "test"})
+    assert result["query"] == "test"
+    assert result["key"] == "secret123"
+
+
+def test_build_langchain_tools_with_custom_tools():
+    """Test build_langchain_tools includes custom tools."""
+    @tool
+    def my_custom_tool(value: str) -> str:
+        """Custom tool for testing."""
+        return value
+
+    tool_specs = [ToolSpec(type=f"{__name__}.my_custom_tool")]
+    tools = build_langchain_tools(tool_specs)
+
+    assert len(tools) == 1
+    assert tools[0].name == f"my_custom_tool"
+
+
+def test_auto_import_with_dotted_path():
+    """Test that dotted paths trigger auto-import."""
+
+    spec = ToolSpec(type="mymodule.tools.my_tool")
+
+    # Should raise ValueError since module doesn't exist
+    # but it should try the import logic
+    with pytest.raises(ModuleNotFoundError, match="No module named 'mymodule'"):
+        CUSTOM_TOOL_REGISTRY.build(spec)
+
+
+def test_tool_schema_inference():
+    """Test that tool schemas are properly inferred."""
+    @tool(parse_docstring=True)
+    def documented_tool(query: str, limit: int = 10) -> dict:
+        """Search for something.
+
+        Args:
+            query: The search query
+            limit: Maximum results
+        """
+        return {"query": query, "limit": limit}
+
+    spec = ToolSpec(type=f"{__name__}.documented_tool")
+    built_tool = CUSTOM_TOOL_REGISTRY.build(spec)
+
+    # Check schema was created
+    schema = built_tool.args_schema.model_json_schema()
+    assert "query" in schema["properties"]
+    assert "limit" in schema["properties"]
+    assert schema["properties"]["query"]["type"] == "string"
+    assert schema["properties"]["limit"]["type"] == "integer"


### PR DESCRIPTION
Adds `@tool` decorator for creating custom tools with a simple function-based API, complementing the existing class-based `BaseDefaultTool` approach.

#### 1. Tool Decorator (`automa_ai/tools/decorators.py`)
- `@tool` decorator with LangChain integration
- Auto-generates Pydantic schemas from function signatures and docstrings
- Supports config injection via `config_schema` parameter
- Handles both sync and async functions
- `_without_param()` helper hides config parameter from LLM schema

#### 2. Enhanced Registry (`automa_ai/tools/registry.py`)
- Added `CUSTOM_TOOL_REGISTRY` for user-defined tools
- Auto-import support for dotted paths (e.g., `myapp.tools.my_tool`)
- `build_langchain_tools()` checks both DEFAULT and CUSTOM registries
- Default `RuntimeDeps` parameter for convenience

#### 3. Documentation (`docs/tools.md`)
- Custom tool usage guide with examples
- Simple tools, async tools, config-based tools
- Auto-import explanation

#### 4. Example (`examples/custom_tool_demo.py`)
- Working factorial calculator agent using `@tool` decorator