### PR TITLE
Hotfix: Remove checkpointer thread_id scoping for AgentCoreMemorySaver

### DIFF
--- a/automa_ai/agents/langgraph_chatagent.py
+++ b/automa_ai/agents/langgraph_chatagent.py
@@ -127,6 +127,8 @@ class GenericLangGraphChatAgent(BaseAgent):
         self._memory_writer_task: asyncio.Task | None = None
 
     def _checkpoint_thread_id(self, session_id: str) -> str:
+        if AgentCoreMemorySaver is not None and isinstance(self.checkpointer, AgentCoreMemorySaver):
+            return session_id
         return f"{self.agent_name}:{session_id}"
 
     def close(self) -> None:


### PR DESCRIPTION
AgentCoreMemorySaver uses both actor_id and thread_id inside checkpointer configuration, so agent_name is not needed inside this thread_id