### PR TITLE
Refine OTEL recorder context and encoding

### DIFF
--- a/automa_ai/common/agent_executor.py
+++ b/automa_ai/common/agent_executor.py
@@ -77,9 +77,7 @@ class GenericAgentExecutor(AgentExecutor):
             await updater.update_status(state, message)
             return True
         except Exception as exc:
-            self.logger.warning(
-                f"Failed to publish status '{state}' update: {exc}"
-            )
+            self.logger.warning(f"Failed to publish status '{state}' update: {exc}")
             return False
 
     async def execute(self, context: RequestContext, event_queue: EventQueue) -> None:
@@ -110,9 +108,7 @@ class GenericAgentExecutor(AgentExecutor):
         terminal_state_reached = False
 
         user_id = (
-            metadata.get("user_id") or metadata.get("userId")
-            if metadata
-            else None
+            metadata.get("user_id") or metadata.get("userId") if metadata else None
         )
 
         async for item in self.agent.stream(
@@ -159,12 +155,12 @@ class GenericAgentExecutor(AgentExecutor):
                 )
                 continue
 
-            self.logger.info(f"Received the item: {item}")
+            self.logger.debug("Received stream item: %s", item)
             is_task_complete = item["is_task_complete"]
             require_user_input = item["require_user_input"]
 
             if is_task_complete:
-                self.logger.info(
+                self.logger.debug(
                     f"{os.getpid()}: Completing with content: {item['content']}"
                 )
                 if item["response_type"] == "data":
@@ -202,7 +198,7 @@ class GenericAgentExecutor(AgentExecutor):
                 break
 
             if item["content"] != last_text_sent:
-                self.logger.info(f"Continue updates: {item['content']}")
+                self.logger.debug("Continue updates: %s", item["content"])
                 status_published = await self._safe_publish_status(
                     updater=updater,
                     state=TaskState.TASK_STATE_WORKING,

--- a/automa_ai/telemetry/otel.py
+++ b/automa_ai/telemetry/otel.py
@@ -102,10 +102,11 @@ class OpenTelemetryRecorder:
                 return
             for span_id in reversed(list(self._spans)):
                 scope = self._span_scopes.pop(span_id, None)
-                if scope is not None:
-                    scope.__exit__(None, None, None)
                 span = self._spans[span_id]
-                span.end()
+                try:
+                    self._exit_scope(scope)
+                finally:
+                    span.end()
             self._spans.clear()
             self._closed = True
         if self._flush_on_close:
@@ -145,14 +146,15 @@ class OpenTelemetryRecorder:
             self._record_orphan_span_end(record, encoded)
             return
 
-        if encoded.attributes:
-            span.set_attributes(encoded.attributes)
-        if encoded.status is not None:
-            span.set_status(encoded.status)
         scope = self._span_scopes.pop(encoded.span_id or "", None)
-        if scope is not None:
-            scope.__exit__(None, None, None)
-        span.end(end_time=encoded.end_time)
+        try:
+            if encoded.attributes:
+                span.set_attributes(encoded.attributes)
+            if encoded.status is not None:
+                span.set_status(encoded.status)
+            self._exit_scope(scope)
+        finally:
+            span.end(end_time=encoded.end_time)
 
     def _record_event(self, record: EventRecord) -> None:
         encoded = encode_event(record)
@@ -202,6 +204,15 @@ class OpenTelemetryRecorder:
             start_time=timestamp_ns(record.timestamp),
         )
         span.end(end_time=timestamp_ns(record.timestamp))
+
+    @staticmethod
+    def _exit_scope(scope: Any | None) -> None:
+        if scope is None:
+            return
+        try:
+            scope.__exit__(None, None, None)
+        except Exception:
+            logger.debug("OTEL scope exit from foreign context.", exc_info=True)
 
 
 def build_otel_recorder(

--- a/automa_ai/telemetry/otel.py
+++ b/automa_ai/telemetry/otel.py
@@ -2,27 +2,44 @@
 
 from __future__ import annotations
 
-from datetime import datetime
-import json
 import logging
-import re
 import threading
 from pathlib import Path
 from typing import Any
 
 from automa_ai.config.telemetry import TelemetryConfig
+from automa_ai.telemetry.otel_encoder import (
+    encode_event,
+    encode_span_end,
+    encode_span_start,
+    otel_attributes,
+    orphan_span_attributes,
+    parent_context,
+    span_kind_to_otel,
+    timestamp_ns,
+)
 from automa_ai.telemetry.recorders import TelemetryRecorder
+from automa_ai.telemetry.records import (
+    EventRecord,
+    SpanEndRecord,
+    SpanStartRecord,
+    SpanStatus,
+    parse_telemetry_record,
+)
 
 logger = logging.getLogger(__name__)
-_ISO_TIMESTAMP_PATTERN = re.compile(
-    r"^(?P<base>\d{4}-\d{2}-\d{2}[T ]\d{2}:\d{2}:\d{2})"
-    r"(?:\.(?P<fraction>\d+))?"
-    r"(?P<tz>Z|[+-]\d{2}:?\d{2})?$"
-)
 
 
 class OpenTelemetryRecorder:
-    """Translate AUTOMA trace/span/event records into OpenTelemetry spans."""
+    """Translate AUTOMA trace/span/event records into OpenTelemetry spans.
+
+    Important context invariant: recording must stay synchronous on the caller's
+    thread/task. The recorder attaches started spans to OpenTelemetry's current
+    context with ``trace.use_span(...)`` so auto-instrumented work inside the
+    agent or tool sees the AUTOMA span as its parent. Moving record() onto a
+    background queue/thread would attach the span in the worker context instead,
+    breaking parent-child correlation for libraries such as httpx or botocore.
+    """
 
     def __init__(
         self,
@@ -37,6 +54,7 @@ class OpenTelemetryRecorder:
         self._lock = threading.Lock()
         self._closed = False
         self._spans: dict[str, Any] = {}
+        self._span_scopes: dict[str, Any] = {}
         options = config.options or {}
         self._flush_timeout_millis = int(
             options.get("flush_timeout_millis", options.get("timeout_millis", 5000))
@@ -63,13 +81,15 @@ class OpenTelemetryRecorder:
                     "Dropping telemetry item because OpenTelemetry recorder is closed."
                 )
                 return
-            item_type = item.get("type")
-            if item_type == "span_start":
-                self._record_span_start(item)
-            elif item_type == "span_end":
-                self._record_span_end(item)
-            elif item_type == "event":
-                self._record_event(item)
+            record = parse_telemetry_record(item)
+            if record is None:
+                return
+            if isinstance(record, EventRecord):
+                self._record_event(record)
+            elif isinstance(record, SpanEndRecord):
+                self._record_span_end(record)
+            else:
+                self._record_span_start(record)
 
     def flush(self) -> None:
         force_flush = getattr(self._provider, "force_flush", None)
@@ -80,7 +100,11 @@ class OpenTelemetryRecorder:
         with self._lock:
             if self._closed:
                 return
-            for span in list(self._spans.values()):
+            for span_id in reversed(list(self._spans)):
+                scope = self._span_scopes.pop(span_id, None)
+                if scope is not None:
+                    scope.__exit__(None, None, None)
+                span = self._spans[span_id]
                 span.end()
             self._spans.clear()
             self._closed = True
@@ -90,136 +114,94 @@ class OpenTelemetryRecorder:
         if self._shutdown_on_close and callable(shutdown):
             shutdown()
 
-    def _record_span_start(self, item: dict[str, Any]) -> None:
-        span_id = str(item.get("span_id") or "")
-        if not span_id:
+    def _record_span_start(self, record: SpanStartRecord) -> None:
+        encoded = encode_span_start(
+            record,
+            otel=self._otel,
+            active_spans=self._spans,
+        )
+        if encoded is None:
             return
-        semantic_attributes = _semantic_attributes(
-            str(item.get("name") or ""),
-            dict(item.get("attributes") or {}),
-        )
-        attributes = _otel_attributes(
-            {
-                **semantic_attributes,
-                "automa.trace_id": item.get("trace_id"),
-                "automa.span_id": span_id,
-                "automa.parent_span_id": item.get("parent_span_id"),
-            }
-        )
-        trace_id = _trace_id_to_int(item.get("trace_id"))
-        otel_span_id = _span_id_to_int(span_id)
-        with self._id_generator.use(trace_id=trace_id, span_id=otel_span_id):
+        with self._id_generator.use(
+            trace_id=encoded.trace_id,
+            span_id=encoded.otel_span_id,
+        ):
             span = self._tracer.start_span(
-                _span_name(str(item.get("name") or "automa.span"), semantic_attributes),
-                context=self._parent_context(item),
-                kind=_span_kind(str(item.get("kind") or "internal"), self._otel),
-                attributes=attributes,
-                start_time=_timestamp_ns(item.get("timestamp")),
+                encoded.name,
+                context=encoded.context,
+                kind=encoded.kind,
+                attributes=encoded.attributes,
+                start_time=encoded.start_time,
             )
-        self._spans[span_id] = span
+        scope = self._otel.trace.use_span(span, end_on_exit=False)
+        scope.__enter__()
+        self._span_scopes[encoded.span_id] = scope
+        self._spans[encoded.span_id] = span
 
-    def _record_span_end(self, item: dict[str, Any]) -> None:
-        span_id = str(item.get("span_id") or "")
-        span = self._spans.pop(span_id, None)
+    def _record_span_end(self, record: SpanEndRecord) -> None:
+        encoded = encode_span_end(record, otel=self._otel)
+        span = self._spans.pop(encoded.span_id or "", None)
         if span is None:
-            self._record_orphan_span_end(item)
+            self._record_orphan_span_end(record, encoded)
             return
 
-        attributes = _otel_attributes(item.get("attributes") or {})
-        if attributes:
-            span.set_attributes(attributes)
-        if item.get("status") == "error":
-            span.set_status(
-                self._otel.Status(
-                    self._otel.StatusCode.ERROR,
-                    _status_description(item.get("attributes") or {}),
-                )
-            )
-        elif item.get("status") == "ok":
-            span.set_status(self._otel.Status(self._otel.StatusCode.OK))
-        span.end(end_time=_timestamp_ns(item.get("timestamp")))
+        if encoded.attributes:
+            span.set_attributes(encoded.attributes)
+        if encoded.status is not None:
+            span.set_status(encoded.status)
+        scope = self._span_scopes.pop(encoded.span_id or "", None)
+        if scope is not None:
+            scope.__exit__(None, None, None)
+        span.end(end_time=encoded.end_time)
 
-    def _record_event(self, item: dict[str, Any]) -> None:
-        span_id = item.get("span_id")
-        span = self._spans.get(str(span_id)) if span_id else None
-        semantic_attributes = _semantic_attributes(
-            str(item.get("name") or ""),
-            dict(item.get("attributes") or {}),
-        )
-        attributes = _otel_attributes(
-            {
-                **semantic_attributes,
-                "automa.trace_id": item.get("trace_id"),
-                "automa.span_id": span_id,
-            }
-        )
+    def _record_event(self, record: EventRecord) -> None:
+        encoded = encode_event(record)
+        span = self._spans.get(str(encoded.span_id)) if encoded.span_id else None
         if span is not None:
+            if record.name == "model.usage" and encoded.attributes:
+                span.set_attributes(encoded.attributes)
             span.add_event(
-                str(item.get("name") or "event"),
-                attributes=attributes,
-                timestamp=_timestamp_ns(item.get("timestamp")),
+                encoded.name,
+                attributes=encoded.attributes,
+                timestamp=encoded.timestamp,
             )
             return
 
-        self._record_orphan_event(item, attributes)
+        self._record_orphan_event(record, encoded.attributes)
 
-    def _record_orphan_span_end(self, item: dict[str, Any]) -> None:
-        attributes = _otel_attributes(
-            {
-                **dict(item.get("attributes") or {}),
-                "automa.trace_id": item.get("trace_id"),
-                "automa.span_id": item.get("span_id"),
-                "automa.parent_span_id": item.get("parent_span_id"),
-                "automa.orphan_span_end": True,
-            }
-        )
+    def _record_orphan_span_end(self, record: SpanEndRecord, encoded: Any) -> None:
         span = self._tracer.start_span(
-            str(item.get("name") or "automa.orphan_span_end"),
-            context=self._parent_context(item),
-            kind=_span_kind(str(item.get("kind") or "internal"), self._otel),
-            attributes=attributes,
-            start_time=_timestamp_ns(item.get("timestamp")),
+            record.name or "automa.orphan_span_end",
+            context=parent_context(
+                record.trace_id,
+                record.parent_span_id,
+                self._spans,
+                self._otel,
+            ),
+            kind=span_kind_to_otel(record.kind, self._otel),
+            attributes=orphan_span_attributes(record),
+            start_time=encoded.end_time,
         )
-        if item.get("status") == "error":
-            span.set_status(
-                self._otel.Status(
-                    self._otel.StatusCode.ERROR,
-                    _status_description(item.get("attributes") or {}),
-                )
-            )
-        span.end(end_time=_timestamp_ns(item.get("timestamp")))
+        if record.status is SpanStatus.ERROR and encoded.status is not None:
+            span.set_status(encoded.status)
+        span.end(end_time=encoded.end_time)
 
     def _record_orphan_event(
         self,
-        item: dict[str, Any],
+        record: EventRecord,
         attributes: dict[str, Any],
     ) -> None:
         span = self._tracer.start_span(
-            str(item.get("name") or "automa.event"),
-            context=self._parent_context(item),
+            record.name or "automa.event",
+            context=None,
             kind=self._otel.SpanKind.INTERNAL,
             attributes={
                 **attributes,
                 "automa.orphan_event": True,
             },
-            start_time=_timestamp_ns(item.get("timestamp")),
+            start_time=timestamp_ns(record.timestamp),
         )
-        span.end(end_time=_timestamp_ns(item.get("timestamp")))
-
-    def _parent_context(self, item: dict[str, Any]) -> Any | None:
-        parent_span_id = item.get("parent_span_id")
-        if parent_span_id:
-            parent = self._spans.get(str(parent_span_id))
-            if parent is not None:
-                return self._otel.trace.set_span_in_context(parent)
-            remote_parent = _remote_parent_context(
-                item.get("trace_id"),
-                str(parent_span_id),
-                self._otel,
-            )
-            if remote_parent is not None:
-                return remote_parent
-        return None
+        span.end(end_time=timestamp_ns(record.timestamp))
 
 
 def build_otel_recorder(
@@ -240,7 +222,7 @@ def _build_tracer_provider(
     id_generator: Any,
 ) -> Any:
     options = config.options or {}
-    resource_attributes = _otel_attributes(
+    resource_attributes = otel_attributes(
         {
             "service.name": config.service_name,
             "deployment.environment": config.environment,
@@ -393,156 +375,6 @@ def _import_otel() -> Any:
     return otel
 
 
-def _span_kind(kind: str, otel: Any) -> Any:
-    normalized = kind.lower().replace("-", "_")
-    return {
-        "server": otel.SpanKind.SERVER,
-        "client": otel.SpanKind.CLIENT,
-        "producer": otel.SpanKind.PRODUCER,
-        "consumer": otel.SpanKind.CONSUMER,
-        "internal": otel.SpanKind.INTERNAL,
-    }.get(normalized, otel.SpanKind.INTERNAL)
-
-
-def _timestamp_ns(value: Any) -> int | None:
-    if not isinstance(value, str) or not value:
-        return None
-    match = _ISO_TIMESTAMP_PATTERN.match(value.strip())
-    if match is None:
-        return None
-    tz = match.group("tz") or "+00:00"
-    if tz == "Z":
-        tz = "+00:00"
-    text = f"{match.group('base')}{tz}"
-    fraction = match.group("fraction") or ""
-    try:
-        epoch_seconds = int(datetime.fromisoformat(text).timestamp())
-    except ValueError:
-        return None
-    fractional_ns = int(fraction.ljust(9, "0")[:9]) if fraction else 0
-    return epoch_seconds * 1_000_000_000 + fractional_ns
-
-
-def _remote_parent_context(trace_id: Any, parent_span_id: str, otel: Any) -> Any | None:
-    trace_int = _trace_id_to_int(trace_id)
-    span_int = _span_id_to_int(parent_span_id)
-    if trace_int is None or span_int is None:
-        return None
-    context = otel.SpanContext(
-        trace_id=trace_int,
-        span_id=span_int,
-        is_remote=True,
-        trace_flags=otel.TraceFlags(otel.TraceFlags.SAMPLED),
-        trace_state=otel.TraceState(),
-    )
-    return otel.trace.set_span_in_context(otel.NonRecordingSpan(context))
-
-
-def _trace_id_to_int(value: Any) -> int | None:
-    if not isinstance(value, str):
-        return None
-    text = value.strip().replace("-", "")
-    if len(text) != 32:
-        return None
-    try:
-        trace_id = int(text, 16)
-    except ValueError:
-        return None
-    return trace_id or None
-
-
-def _span_id_to_int(value: Any) -> int | None:
-    if not isinstance(value, str):
-        return None
-    text = value.strip().replace("-", "")
-    if len(text) != 16:
-        return None
-    try:
-        span_id = int(text, 16)
-    except ValueError:
-        return None
-    return span_id or None
-
-
-def _semantic_attributes(span_name: str, attributes: dict[str, Any]) -> dict[str, Any]:
-    enriched = dict(attributes)
-    if span_name == "agent.turn":
-        enriched.setdefault("gen_ai.operation.name", "invoke_agent")
-        enriched.setdefault("gen_ai.provider.name", "automa_ai")
-        if "agent.name" in enriched:
-            enriched.setdefault("gen_ai.agent.name", enriched["agent.name"])
-        if "agent.description" in enriched:
-            enriched.setdefault(
-                "gen_ai.agent.description", enriched["agent.description"]
-            )
-        if "agent.version" in enriched:
-            enriched.setdefault("gen_ai.agent.version", enriched["agent.version"])
-        if "model.name" in enriched:
-            enriched.setdefault("gen_ai.request.model", enriched["model.name"])
-        if "model.provider" in enriched:
-            enriched.setdefault("gen_ai.provider.name", enriched["model.provider"])
-    elif span_name == "tool.call":
-        enriched.setdefault("gen_ai.operation.name", "execute_tool")
-        enriched.setdefault("gen_ai.provider.name", "automa_ai")
-        if "tool.name" in enriched:
-            enriched.setdefault("gen_ai.tool.name", enriched["tool.name"])
-    if "model.provider" in enriched:
-        enriched.setdefault("gen_ai.provider.name", enriched["model.provider"])
-    if "model.name" in enriched:
-        enriched.setdefault("gen_ai.request.model", enriched["model.name"])
-    if "model.response_name" in enriched:
-        enriched.setdefault("gen_ai.response.model", enriched["model.response_name"])
-    if "model.usage.input_tokens" in enriched:
-        enriched.setdefault(
-            "gen_ai.usage.input_tokens",
-            enriched["model.usage.input_tokens"],
-        )
-    if "model.usage.output_tokens" in enriched:
-        enriched.setdefault(
-            "gen_ai.usage.output_tokens",
-            enriched["model.usage.output_tokens"],
-        )
-    return enriched
-
-
-def _span_name(original_name: str, attributes: dict[str, Any]) -> str:
-    operation = attributes.get("gen_ai.operation.name")
-    if not operation:
-        return original_name
-    if operation == "invoke_agent" and attributes.get("gen_ai.agent.name"):
-        return f"{operation} {attributes['gen_ai.agent.name']}"
-    if operation == "execute_tool" and attributes.get("gen_ai.tool.name"):
-        return f"{operation} {attributes['gen_ai.tool.name']}"
-    return str(operation)
-
-
-def _otel_attributes(attributes: dict[str, Any]) -> dict[str, Any]:
-    result: dict[str, Any] = {}
-    for key, value in attributes.items():
-        if value is None:
-            continue
-        result[str(key)] = _otel_attribute_value(value)
-    return result
-
-
-def _otel_attribute_value(value: Any) -> Any:
-    if isinstance(value, (str, bool, int, float)):
-        return value
-    if isinstance(value, (list, tuple)):
-        if all(isinstance(item, str) for item in value):
-            return list(value)
-        if all(isinstance(item, bool) for item in value):
-            return list(value)
-        if all(isinstance(item, int) and not isinstance(item, bool) for item in value):
-            return list(value)
-        if all(
-            isinstance(item, (int, float)) and not isinstance(item, bool)
-            for item in value
-        ):
-            return list(value)
-    return json.dumps(value, default=str, ensure_ascii=False, sort_keys=True)
-
-
 def _normalize_headers(value: Any) -> dict[str, str] | str | None:
     if value is None:
         return None
@@ -559,12 +391,3 @@ def _normalize_headers(value: Any) -> dict[str, str] | str | None:
                 headers[key] = item.strip()
         return headers or value
     return value
-
-
-def _status_description(attributes: dict[str, Any]) -> str | None:
-    message = attributes.get("exception.message")
-    if isinstance(message, str):
-        return message
-    if isinstance(message, dict):
-        return str(message.get("content") or message.get("sha256") or "")
-    return None

--- a/automa_ai/telemetry/otel_encoder.py
+++ b/automa_ai/telemetry/otel_encoder.py
@@ -176,6 +176,8 @@ def timestamp_ns(value: Any) -> int | None:
     tz = match.group("tz") or "+00:00"
     if tz == "Z":
         tz = "+00:00"
+    elif len(tz) == 5 and tz[0] in "+-" and ":" not in tz:
+        tz = f"{tz[:3]}:{tz[3:]}"
     text = f"{match.group('base')}{tz}"
     fraction = match.group("fraction") or ""
     try:

--- a/automa_ai/telemetry/otel_encoder.py
+++ b/automa_ai/telemetry/otel_encoder.py
@@ -1,0 +1,307 @@
+"""OpenTelemetry encoding helpers for AUTOMA telemetry records."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+import json
+import re
+from typing import Any
+
+from automa_ai.telemetry.records import (
+    EventRecord,
+    SpanEndRecord,
+    SpanKind,
+    SpanStartRecord,
+    SpanStatus,
+)
+
+_ISO_TIMESTAMP_PATTERN = re.compile(
+    r"^(?P<base>\d{4}-\d{2}-\d{2}[T ]\d{2}:\d{2}:\d{2})"
+    r"(?:\.(?P<fraction>\d+))?"
+    r"(?P<tz>Z|[+-]\d{2}:?\d{2})?$"
+)
+
+
+@dataclass(frozen=True)
+class EncodedSpanStart:
+    span_id: str
+    trace_id: int | None
+    otel_span_id: int | None
+    name: str
+    context: Any | None
+    kind: Any
+    attributes: dict[str, Any]
+    start_time: int | None
+
+
+@dataclass(frozen=True)
+class EncodedSpanEnd:
+    span_id: str | None
+    status: Any | None
+    attributes: dict[str, Any]
+    end_time: int | None
+
+
+@dataclass(frozen=True)
+class EncodedEvent:
+    span_id: str | None
+    name: str
+    attributes: dict[str, Any]
+    timestamp: int | None
+
+
+def encode_span_start(
+    record: SpanStartRecord,
+    *,
+    otel: Any,
+    active_spans: dict[str, Any],
+) -> EncodedSpanStart | None:
+    if not record.span_id:
+        return None
+    semantic_attributes = _semantic_attributes(record.name, dict(record.attributes))
+    attributes = otel_attributes(
+        {
+            **semantic_attributes,
+            "automa.trace_id": record.trace_id,
+            "automa.span_id": record.span_id,
+            "automa.parent_span_id": record.parent_span_id,
+        }
+    )
+    return EncodedSpanStart(
+        span_id=record.span_id,
+        trace_id=_trace_id_to_int(record.trace_id),
+        otel_span_id=_span_id_to_int(record.span_id),
+        name=_span_name(record.name or "automa.span", semantic_attributes),
+        context=parent_context(
+            record.trace_id, record.parent_span_id, active_spans, otel
+        ),
+        kind=span_kind_to_otel(record.kind, otel),
+        attributes=attributes,
+        start_time=timestamp_ns(record.timestamp),
+    )
+
+
+def encode_span_end(record: SpanEndRecord, *, otel: Any) -> EncodedSpanEnd:
+    status = None
+    if record.status is SpanStatus.ERROR:
+        status = otel.Status(
+            otel.StatusCode.ERROR,
+            status_description(record.attributes),
+        )
+    elif record.status is SpanStatus.OK:
+        status = otel.Status(otel.StatusCode.OK)
+    return EncodedSpanEnd(
+        span_id=record.span_id,
+        status=status,
+        attributes=otel_attributes(dict(record.attributes)),
+        end_time=timestamp_ns(record.timestamp),
+    )
+
+
+def encode_event(record: EventRecord) -> EncodedEvent:
+    semantic_attributes = _semantic_attributes(record.name, dict(record.attributes))
+    attributes = otel_attributes(
+        {
+            **semantic_attributes,
+            "automa.trace_id": record.trace_id,
+            "automa.span_id": record.span_id,
+        }
+    )
+    return EncodedEvent(
+        span_id=record.span_id,
+        name=record.name or "event",
+        attributes=attributes,
+        timestamp=timestamp_ns(record.timestamp),
+    )
+
+
+def orphan_span_attributes(record: SpanEndRecord) -> dict[str, Any]:
+    return otel_attributes(
+        {
+            **dict(record.attributes),
+            "automa.trace_id": record.trace_id,
+            "automa.span_id": record.span_id,
+            "automa.parent_span_id": record.parent_span_id,
+            "automa.orphan_span_end": True,
+        }
+    )
+
+
+def parent_context(
+    trace_id: str | None,
+    parent_span_id: str | None,
+    active_spans: dict[str, Any],
+    otel: Any,
+) -> Any | None:
+    if not parent_span_id:
+        return None
+    parent = active_spans.get(str(parent_span_id))
+    if parent is not None:
+        return otel.trace.set_span_in_context(parent)
+    return remote_parent_context(trace_id, parent_span_id, otel)
+
+
+def remote_parent_context(trace_id: Any, parent_span_id: str, otel: Any) -> Any | None:
+    trace_int = _trace_id_to_int(trace_id)
+    span_int = _span_id_to_int(parent_span_id)
+    if trace_int is None or span_int is None:
+        return None
+    context = otel.SpanContext(
+        trace_id=trace_int,
+        span_id=span_int,
+        is_remote=True,
+        trace_flags=otel.TraceFlags(otel.TraceFlags.SAMPLED),
+        trace_state=otel.TraceState(),
+    )
+    return otel.trace.set_span_in_context(otel.NonRecordingSpan(context))
+
+
+def span_kind_to_otel(kind: SpanKind, otel: Any) -> Any:
+    return {
+        SpanKind.SERVER: otel.SpanKind.SERVER,
+        SpanKind.CLIENT: otel.SpanKind.CLIENT,
+        SpanKind.PRODUCER: otel.SpanKind.PRODUCER,
+        SpanKind.CONSUMER: otel.SpanKind.CONSUMER,
+        SpanKind.INTERNAL: otel.SpanKind.INTERNAL,
+    }.get(kind, otel.SpanKind.INTERNAL)
+
+
+def timestamp_ns(value: Any) -> int | None:
+    if not isinstance(value, str) or not value:
+        return None
+    match = _ISO_TIMESTAMP_PATTERN.match(value.strip())
+    if match is None:
+        return None
+    tz = match.group("tz") or "+00:00"
+    if tz == "Z":
+        tz = "+00:00"
+    text = f"{match.group('base')}{tz}"
+    fraction = match.group("fraction") or ""
+    try:
+        epoch_seconds = int(datetime.fromisoformat(text).timestamp())
+    except ValueError:
+        return None
+    fractional_ns = int(fraction.ljust(9, "0")[:9]) if fraction else 0
+    return epoch_seconds * 1_000_000_000 + fractional_ns
+
+
+def _trace_id_to_int(value: Any) -> int | None:
+    if not isinstance(value, str):
+        return None
+    text = value.strip().replace("-", "")
+    if len(text) != 32:
+        return None
+    try:
+        trace_id = int(text, 16)
+    except ValueError:
+        return None
+    return trace_id or None
+
+
+def _span_id_to_int(value: Any) -> int | None:
+    if not isinstance(value, str):
+        return None
+    text = value.strip().replace("-", "")
+    if len(text) != 16:
+        return None
+    try:
+        span_id = int(text, 16)
+    except ValueError:
+        return None
+    return span_id or None
+
+
+def _semantic_attributes(span_name: str, attributes: dict[str, Any]) -> dict[str, Any]:
+    enriched = dict(attributes)
+    if span_name == "agent.turn":
+        enriched.setdefault("gen_ai.operation.name", "invoke_agent")
+        enriched.setdefault("gen_ai.provider.name", "automa_ai")
+        if "agent.name" in enriched:
+            enriched.setdefault("gen_ai.agent.name", enriched["agent.name"])
+        if "agent.description" in enriched:
+            enriched.setdefault(
+                "gen_ai.agent.description", enriched["agent.description"]
+            )
+        if "agent.version" in enriched:
+            enriched.setdefault("gen_ai.agent.version", enriched["agent.version"])
+        if "model.name" in enriched:
+            enriched.setdefault("gen_ai.request.model", enriched["model.name"])
+        if "model.provider" in enriched:
+            enriched.setdefault("gen_ai.provider.name", enriched["model.provider"])
+    elif span_name == "tool.call":
+        enriched.setdefault("gen_ai.operation.name", "execute_tool")
+        enriched.setdefault("gen_ai.provider.name", "automa_ai")
+        if "tool.name" in enriched:
+            enriched.setdefault("gen_ai.tool.name", enriched["tool.name"])
+    if "model.provider" in enriched:
+        enriched.setdefault("gen_ai.provider.name", enriched["model.provider"])
+    if "model.name" in enriched:
+        enriched.setdefault("gen_ai.request.model", enriched["model.name"])
+    if "model.response_name" in enriched:
+        enriched.setdefault("gen_ai.response.model", enriched["model.response_name"])
+    if "model.usage.input_tokens" in enriched:
+        enriched.setdefault(
+            "gen_ai.usage.input_tokens",
+            enriched["model.usage.input_tokens"],
+        )
+    if "model.usage.output_tokens" in enriched:
+        enriched.setdefault(
+            "gen_ai.usage.output_tokens",
+            enriched["model.usage.output_tokens"],
+        )
+    if "model.usage.total_tokens" in enriched:
+        enriched.setdefault(
+            "gen_ai.usage.total_tokens",
+            enriched["model.usage.total_tokens"],
+        )
+    return enriched
+
+
+def _span_name(original_name: str, attributes: dict[str, Any]) -> str:
+    operation = attributes.get("gen_ai.operation.name")
+    if not operation:
+        return original_name
+    if operation == "invoke_agent" and attributes.get("gen_ai.agent.name"):
+        return f"{operation} {attributes['gen_ai.agent.name']}"
+    if operation == "execute_tool" and attributes.get("gen_ai.tool.name"):
+        return f"{operation} {attributes['gen_ai.tool.name']}"
+    return str(operation)
+
+
+def otel_attributes(attributes: dict[str, Any]) -> dict[str, Any]:
+    result: dict[str, Any] = {}
+    for key, value in attributes.items():
+        if value is None:
+            continue
+        result[str(key)] = _otel_attribute_value(value)
+    return result
+
+
+def _otel_attribute_value(value: Any) -> Any:
+    if isinstance(value, (str, bool, int, float)):
+        return value
+    if isinstance(value, (list, tuple)):
+        if all(isinstance(item, str) for item in value):
+            return list(value)
+        if all(isinstance(item, bool) for item in value):
+            return list(value)
+        if all(isinstance(item, int) and not isinstance(item, bool) for item in value):
+            return list(value)
+        if all(
+            isinstance(item, (int, float)) and not isinstance(item, bool)
+            for item in value
+        ):
+            return list(value)
+    return json.dumps(value, default=str, ensure_ascii=False, sort_keys=True)
+
+
+def status_description(attributes: Any) -> str | None:
+    if not isinstance(attributes, dict):
+        attributes = dict(attributes or {})
+    message = attributes.get("exception.message")
+    if isinstance(message, str):
+        return message
+    if isinstance(message, dict):
+        return str(message.get("content") or message.get("sha256") or "")
+    return None

--- a/automa_ai/telemetry/records.py
+++ b/automa_ai/telemetry/records.py
@@ -1,0 +1,150 @@
+"""Pure AUTOMA telemetry record model.
+
+This module intentionally has no OpenTelemetry imports. It models the internal
+record shapes emitted by the telemetry facade so recorders can distinguish
+AUTOMA data from backend-specific SDK values.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass
+from enum import Enum
+from typing import Any
+
+
+class SpanKind(str, Enum):
+    INTERNAL = "internal"
+    SERVER = "server"
+    CLIENT = "client"
+    PRODUCER = "producer"
+    CONSUMER = "consumer"
+
+
+class SpanStatus(str, Enum):
+    OK = "ok"
+    ERROR = "error"
+
+
+@dataclass(frozen=True)
+class SpanStartRecord:
+    trace_id: str | None
+    span_id: str | None
+    parent_span_id: str | None
+    name: str
+    kind: SpanKind
+    timestamp: str | None
+    attributes: Mapping[str, Any]
+
+
+@dataclass(frozen=True)
+class SpanEndRecord:
+    trace_id: str | None
+    span_id: str | None
+    parent_span_id: str | None
+    name: str
+    kind: SpanKind
+    timestamp: str | None
+    status: SpanStatus | None
+    duration_ms: float | None
+    attributes: Mapping[str, Any]
+
+
+@dataclass(frozen=True)
+class EventRecord:
+    trace_id: str | None
+    span_id: str | None
+    name: str
+    timestamp: str | None
+    attributes: Mapping[str, Any]
+
+
+TelemetryRecord = SpanStartRecord | SpanEndRecord | EventRecord
+
+
+def parse_telemetry_record(item: Mapping[str, Any] | None) -> TelemetryRecord | None:
+    """Leniently parse a raw facade dictionary into an AUTOMA record.
+
+    Unknown record types, malformed records, and unsupported enum values should
+    never raise into recorder code. The OTEL recorder can skip ``None`` while
+    JSONL remains a raw-dict passthrough.
+    """
+    if not isinstance(item, Mapping):
+        return None
+    item_type = item.get("type")
+    if item_type == "span_start":
+        return SpanStartRecord(
+            trace_id=_optional_str(item.get("trace_id")),
+            span_id=_optional_str(item.get("span_id")),
+            parent_span_id=_optional_str(item.get("parent_span_id")),
+            name=_str_or_empty(item.get("name")),
+            kind=_span_kind(item.get("kind")),
+            timestamp=_optional_str(item.get("timestamp")),
+            attributes=_attributes(item.get("attributes")),
+        )
+    if item_type == "span_end":
+        return SpanEndRecord(
+            trace_id=_optional_str(item.get("trace_id")),
+            span_id=_optional_str(item.get("span_id")),
+            parent_span_id=_optional_str(item.get("parent_span_id")),
+            name=_str_or_empty(item.get("name")),
+            kind=_span_kind(item.get("kind")),
+            timestamp=_optional_str(item.get("timestamp")),
+            status=_span_status(item.get("status")),
+            duration_ms=_optional_float(item.get("duration_ms")),
+            attributes=_attributes(item.get("attributes")),
+        )
+    if item_type == "event":
+        return EventRecord(
+            trace_id=_optional_str(item.get("trace_id")),
+            span_id=_optional_str(item.get("span_id")),
+            name=_str_or_empty(item.get("name")),
+            timestamp=_optional_str(item.get("timestamp")),
+            attributes=_attributes(item.get("attributes")),
+        )
+    return None
+
+
+def _span_kind(value: Any) -> SpanKind:
+    text = str(value or "").lower().replace("-", "_")
+    return {
+        "server": SpanKind.SERVER,
+        "client": SpanKind.CLIENT,
+        "producer": SpanKind.PRODUCER,
+        "consumer": SpanKind.CONSUMER,
+        "internal": SpanKind.INTERNAL,
+    }.get(text, SpanKind.INTERNAL)
+
+
+def _span_status(value: Any) -> SpanStatus | None:
+    text = str(value or "").lower()
+    return {
+        "ok": SpanStatus.OK,
+        "error": SpanStatus.ERROR,
+    }.get(text)
+
+
+def _attributes(value: Any) -> Mapping[str, Any]:
+    if isinstance(value, Mapping):
+        return value
+    return {}
+
+
+def _optional_str(value: Any) -> str | None:
+    if value is None:
+        return None
+    text = str(value)
+    return text if text else None
+
+
+def _str_or_empty(value: Any) -> str:
+    return "" if value is None else str(value)
+
+
+def _optional_float(value: Any) -> float | None:
+    if value is None or isinstance(value, bool):
+        return None
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return None

--- a/docs/telemetry.md
+++ b/docs/telemetry.md
@@ -162,6 +162,16 @@ recycling or request teardown. Set `flush_on_close: true` or
 `shutdown_on_close: true` only in lifecycle code where that blocking behavior is
 acceptable, and prefer `Telemetry.aclose()` in async applications.
 
+Do not move OTEL `record()` calls behind a background queue or worker thread.
+The recorder intentionally runs synchronously in the caller's thread/task so
+`trace.use_span(...)` attaches the AUTOMA span to the same OpenTelemetry context
+that auto-instrumented libraries such as `httpx`, `requests`, `botocore`, and
+model SDKs read from. If span start/end recording happens in a different worker
+context than the tool/model call, those auto-instrumented child spans will not
+inherit the AUTOMA `agent.turn` or `tool.call` parent span. Concurrent tool
+calls are supported when each span starts, runs, and ends inside its own asyncio
+task/thread context; do not start a span in one task and end it in another.
+
 ## Custom Recorders
 
 A recorder implements three methods:

--- a/docs/yaml_agent_spec.md
+++ b/docs/yaml_agent_spec.md
@@ -747,6 +747,13 @@ expose it. Cost and prompt/completion rendering are not synthesized.
 Telemetry recording is best-effort: recorder failures are logged and dropped so
 they do not fail agent requests.
 
+Keep OTEL recording synchronous in the agent/tool execution context. The recorder
+uses OpenTelemetry context attachment so auto-instrumented libraries can inherit
+the current AUTOMA span. Do not move OTEL `record()` behind a background queue or
+worker thread, or downstream spans may stop appearing under `agent.turn` and
+`tool.call`. Concurrent tool calls are supported only when each span starts,
+runs, and ends inside its own asyncio task/thread context.
+
 Relative JSONL `path` values are resolved from the YAML file's directory.
 See `docs/telemetry.md` for privacy modes, custom recorder registration, and an
 OpenTelemetry/AgentCore adapter guidance.

--- a/tests/test_telemetry.py
+++ b/tests/test_telemetry.py
@@ -21,12 +21,20 @@ from automa_ai.telemetry import (
     wrap_langchain_tool,
 )
 from automa_ai.telemetry import otel as otel_module
+from automa_ai.telemetry import otel_encoder
 from automa_ai.telemetry import registry as telemetry_registry
 from automa_ai.telemetry.recorders import JsonlRecorder
+from automa_ai.telemetry.records import (
+    EventRecord,
+    SpanKind,
+    SpanStartRecord,
+    parse_telemetry_record,
+)
 
 otel_exporter = pytest.importorskip(
     "opentelemetry.sdk.trace.export.in_memory_span_exporter"
 )
+otel_trace = pytest.importorskip("opentelemetry.trace")
 InMemorySpanExporter = otel_exporter.InMemorySpanExporter
 
 
@@ -270,6 +278,41 @@ def test_custom_recorder_registry_builds_registered_recorder(tmp_path) -> None:
     assert "test_custom_agentcore" in list_telemetry_recorders()
 
 
+def test_parse_telemetry_record_models_distinct_shapes_leniently() -> None:
+    start = parse_telemetry_record(
+        {
+            "type": "span_start",
+            "trace_id": "trace",
+            "span_id": "span",
+            "parent_span_id": "parent",
+            "name": "agent.turn",
+            "kind": "unexpected-kind",
+            "timestamp": "2026-01-01T00:00:00.000000000Z",
+            "attributes": {"agent.name": "demo"},
+        }
+    )
+    event = parse_telemetry_record(
+        {
+            "type": "event",
+            "trace_id": "trace",
+            "span_id": None,
+            "name": "message",
+            "timestamp": "2026-01-01T00:00:00.000000000Z",
+            "attributes": {"content": "hello"},
+            "kind": "ignored",
+        }
+    )
+
+    assert isinstance(start, SpanStartRecord)
+    assert start.kind is SpanKind.INTERNAL
+    assert start.parent_span_id == "parent"
+    assert isinstance(event, EventRecord)
+    assert event.span_id is None
+    assert not hasattr(event, "kind")
+    assert parse_telemetry_record({"type": "future_record"}) is None
+    assert parse_telemetry_record(None) is None
+
+
 def test_otel_recorder_exports_spans_events_and_status(monkeypatch) -> None:
     exporter = InMemorySpanExporter()
     monkeypatch.setattr(
@@ -317,7 +360,7 @@ def test_otel_recorder_exports_spans_events_and_status(monkeypatch) -> None:
     assert tool_span.attributes["gen_ai.operation.name"] == "execute_tool"
     assert tool_span.attributes["gen_ai.tool.name"] == "demo_tool"
     assert agent_span.attributes["gen_ai.operation.name"] == "invoke_agent"
-    assert agent_span.attributes["gen_ai.provider.name"] == "automa_ai"
+    assert agent_span.attributes["gen_ai.provider.name"] == "openai"
     assert (
         agent_span.attributes["automa.span_id"] == f"{agent_span.context.span_id:016x}"
     )
@@ -336,7 +379,11 @@ def test_otel_recorder_exports_spans_events_and_status(monkeypatch) -> None:
     assert agent_span.events[1].attributes["gen_ai.provider.name"] == "openai"
     assert agent_span.events[1].attributes["gen_ai.usage.input_tokens"] == 11
     assert agent_span.events[1].attributes["gen_ai.usage.output_tokens"] == 4
+    assert agent_span.events[1].attributes["gen_ai.usage.total_tokens"] == 15
     assert agent_span.events[1].attributes["model.usage.total_tokens"] == 15
+    assert agent_span.attributes["gen_ai.usage.input_tokens"] == 11
+    assert agent_span.attributes["gen_ai.usage.output_tokens"] == 4
+    assert agent_span.attributes["gen_ai.usage.total_tokens"] == 15
     assert agent_span.resource.attributes["service.name"] == "test-service"
 
 
@@ -389,22 +436,94 @@ def test_otel_recorder_uses_remote_parent_without_truncating_ids(monkeypatch) ->
     assert span.context.trace_id == int(trace_id, 16)
     assert span.context.span_id == int(span_id, 16)
     assert span.parent.span_id == int(parent_span_id, 16)
-    assert otel_module._span_id_to_int("4" * 32) is None
+    assert otel_encoder._span_id_to_int("4" * 32) is None
+
+
+def test_otel_recorder_sets_current_span_context_in_caller_task(monkeypatch) -> None:
+    exporter = InMemorySpanExporter()
+    monkeypatch.setattr(
+        otel_module,
+        "_build_exporter",
+        lambda options, otel: exporter,
+    )
+    telemetry = build_telemetry(
+        {
+            "enabled": True,
+            "recorder": "otel",
+            "options": {"processor": "simple"},
+        }
+    )
+
+    with telemetry.span("agent.turn") as parent:
+        # This is the invariant that must hold for auto-instrumented libraries:
+        # record() attaches the AUTOMA span in the same task running the work.
+        current_parent = otel_trace.get_current_span().get_span_context()
+        assert current_parent.trace_id == int(parent.trace_id, 16)
+        assert current_parent.span_id == int(parent.span_id, 16)
+
+        with telemetry.span("tool.call") as child:
+            current_child = otel_trace.get_current_span().get_span_context()
+            assert current_child.trace_id == int(child.trace_id, 16)
+            assert current_child.span_id == int(child.span_id, 16)
+
+        restored_parent = otel_trace.get_current_span().get_span_context()
+        assert restored_parent.span_id == int(parent.span_id, 16)
+
+    assert not otel_trace.get_current_span().get_span_context().is_valid
+
+
+@pytest.mark.asyncio
+async def test_otel_recorder_isolates_concurrent_task_current_spans(
+    monkeypatch,
+) -> None:
+    exporter = InMemorySpanExporter()
+    monkeypatch.setattr(
+        otel_module,
+        "_build_exporter",
+        lambda options, otel: exporter,
+    )
+    telemetry = build_telemetry(
+        {
+            "enabled": True,
+            "recorder": "otel",
+            "options": {"processor": "simple"},
+        }
+    )
+
+    async def run_tool(tool_name: str) -> tuple[str, str, str, str]:
+        with telemetry.span("tool.call", attributes={"tool.name": tool_name}) as scope:
+            start_context = otel_trace.get_current_span().get_span_context()
+            await asyncio.sleep(0)
+            resumed_context = otel_trace.get_current_span().get_span_context()
+            return (
+                tool_name,
+                scope.span_id,
+                f"{start_context.span_id:016x}",
+                f"{resumed_context.span_id:016x}",
+            )
+
+    results = await asyncio.gather(run_tool("tool_a"), run_tool("tool_b"))
+
+    assert {item[0] for item in results} == {"tool_a", "tool_b"}
+    for _tool_name, span_id, start_span_id, resumed_span_id in results:
+        assert start_span_id == span_id
+        assert resumed_span_id == span_id
+    assert not otel_trace.get_current_span().get_span_context().is_valid
 
 
 def test_otel_timestamp_parser_preserves_nanoseconds() -> None:
     assert (
-        otel_module._timestamp_ns("2026-01-01T00:00:00.123456789Z")
+        otel_encoder.timestamp_ns("2026-01-01T00:00:00.123456789Z")
         == 1_767_225_600_123_456_789
     )
     assert (
-        otel_module._timestamp_ns("2026-01-01T00:00:00.1Z") == 1_767_225_600_100_000_000
+        otel_encoder.timestamp_ns("2026-01-01T00:00:00.1Z") == 1_767_225_600_100_000_000
     )
     assert (
-        otel_module._timestamp_ns("2026-01-01T00:00:00.123456789+01:00")
+        otel_encoder.timestamp_ns("2026-01-01T00:00:00.123456789+01:00")
         == 1_767_222_000_123_456_789
     )
-    assert otel_module._timestamp_ns("not-a-timestamp") is None
+    assert otel_encoder.timestamp_ns("not-a-timestamp") is None
 
 
 def test_otel_recorder_flush_is_bounded_and_shutdown_is_opt_in() -> None:

--- a/tests/test_telemetry.py
+++ b/tests/test_telemetry.py
@@ -472,6 +472,96 @@ def test_otel_recorder_sets_current_span_context_in_caller_task(monkeypatch) -> 
     assert not otel_trace.get_current_span().get_span_context().is_valid
 
 
+def test_otel_recorder_ends_span_when_scope_exits_from_foreign_context(
+    monkeypatch,
+) -> None:
+    exporter = InMemorySpanExporter()
+    monkeypatch.setattr(
+        otel_module,
+        "_build_exporter",
+        lambda options, otel: exporter,
+    )
+    telemetry = build_telemetry(
+        {
+            "enabled": True,
+            "recorder": "otel",
+            "options": {"processor": "simple"},
+        }
+    )
+    trace_id = "1" * 32
+    span_id = "2" * 16
+
+    start_record = {
+        "type": "span_start",
+        "trace_id": trace_id,
+        "span_id": span_id,
+        "parent_span_id": None,
+        "name": "agent.turn",
+        "kind": "server",
+        "timestamp": "2026-01-01T00:00:00.000000000Z",
+        "attributes": {},
+    }
+    end_record = {
+        "type": "span_end",
+        "trace_id": trace_id,
+        "span_id": span_id,
+        "parent_span_id": None,
+        "name": "agent.turn",
+        "kind": "server",
+        "timestamp": "2026-01-01T00:00:00.100000000Z",
+        "status": "ok",
+        "attributes": {},
+    }
+
+    contextvars.Context().run(telemetry.recorder.record, start_record)
+    telemetry.recorder.record(end_record)
+    telemetry.flush()
+
+    spans = exporter.get_finished_spans()
+    assert len(spans) == 1
+    assert spans[0].context.trace_id == int(trace_id, 16)
+    assert spans[0].context.span_id == int(span_id, 16)
+    assert spans[0].status.status_code.name == "OK"
+
+
+def test_otel_recorder_close_ends_all_spans_with_foreign_scope_contexts(
+    monkeypatch,
+) -> None:
+    exporter = InMemorySpanExporter()
+    monkeypatch.setattr(
+        otel_module,
+        "_build_exporter",
+        lambda options, otel: exporter,
+    )
+    telemetry = build_telemetry(
+        {
+            "enabled": True,
+            "recorder": "otel",
+            "options": {"processor": "simple"},
+        }
+    )
+
+    for value in ("2", "3"):
+        contextvars.Context().run(
+            telemetry.recorder.record,
+            {
+                "type": "span_start",
+                "trace_id": "1" * 32,
+                "span_id": value * 16,
+                "parent_span_id": None,
+                "name": f"span-{value}",
+                "kind": "internal",
+                "timestamp": "2026-01-01T00:00:00.000000000Z",
+                "attributes": {},
+            },
+        )
+
+    telemetry.close()
+
+    spans = exporter.get_finished_spans()
+    assert {span.name for span in spans} == {"span-2", "span-3"}
+
+
 @pytest.mark.asyncio
 async def test_otel_recorder_isolates_concurrent_task_current_spans(
     monkeypatch,


### PR DESCRIPTION
Address reviewer feedback by splitting AUTOMA telemetry record models from OTEL encoding logic, keeping records.py stdlib-only and JSONL as a raw-dict passthrough.

Fix AWS observability gaps by mirroring model usage onto active spans, emitting gen_ai.usage.total_tokens, attaching AUTOMA spans to the current OTEL context for auto-instrumented child spans, and lowering stream progress logs to debug.

Document the same-task/thread context invariant for OTEL recording and add regression coverage for lenient record parsing, current-span propagation, and concurrent sibling tool spans.