### PR TITLE
Develop

### DIFF
--- a/automa_ai/telemetry/otel.py
+++ b/automa_ai/telemetry/otel.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from contextvars import Token
 import logging
 import threading
 from pathlib import Path
@@ -35,10 +36,11 @@ class OpenTelemetryRecorder:
 
     Important context invariant: recording must stay synchronous on the caller's
     thread/task. The recorder attaches started spans to OpenTelemetry's current
-    context with ``trace.use_span(...)`` so auto-instrumented work inside the
-    agent or tool sees the AUTOMA span as its parent. Moving record() onto a
-    background queue/thread would attach the span in the worker context instead,
-    breaking parent-child correlation for libraries such as httpx or botocore.
+    context with ``context.attach(trace.set_span_in_context(...))`` so
+    auto-instrumented work inside the agent or tool sees the AUTOMA span as its
+    parent. Moving record() onto a background queue/thread would attach the span
+    in the worker context instead, breaking parent-child correlation for
+    libraries such as httpx or botocore.
     """
 
     def __init__(
@@ -54,7 +56,7 @@ class OpenTelemetryRecorder:
         self._lock = threading.Lock()
         self._closed = False
         self._spans: dict[str, Any] = {}
-        self._span_scopes: dict[str, Any] = {}
+        self._span_tokens: dict[str, Any] = {}
         options = config.options or {}
         self._flush_timeout_millis = int(
             options.get("flush_timeout_millis", options.get("timeout_millis", 5000))
@@ -101,10 +103,10 @@ class OpenTelemetryRecorder:
             if self._closed:
                 return
             for span_id in reversed(list(self._spans)):
-                scope = self._span_scopes.pop(span_id, None)
+                token = self._span_tokens.pop(span_id, None)
                 span = self._spans[span_id]
                 try:
-                    self._exit_scope(scope)
+                    self._detach_token(token)
                 finally:
                     span.end()
             self._spans.clear()
@@ -134,9 +136,8 @@ class OpenTelemetryRecorder:
                 attributes=encoded.attributes,
                 start_time=encoded.start_time,
             )
-        scope = self._otel.trace.use_span(span, end_on_exit=False)
-        scope.__enter__()
-        self._span_scopes[encoded.span_id] = scope
+        token = self._otel.context.attach(self._otel.trace.set_span_in_context(span))
+        self._span_tokens[encoded.span_id] = token
         self._spans[encoded.span_id] = span
 
     def _record_span_end(self, record: SpanEndRecord) -> None:
@@ -146,13 +147,13 @@ class OpenTelemetryRecorder:
             self._record_orphan_span_end(record, encoded)
             return
 
-        scope = self._span_scopes.pop(encoded.span_id or "", None)
+        token = self._span_tokens.pop(encoded.span_id or "", None)
         try:
             if encoded.attributes:
                 span.set_attributes(encoded.attributes)
             if encoded.status is not None:
                 span.set_status(encoded.status)
-            self._exit_scope(scope)
+            self._detach_token(token)
         finally:
             span.end(end_time=encoded.end_time)
 
@@ -206,13 +207,20 @@ class OpenTelemetryRecorder:
         span.end(end_time=timestamp_ns(record.timestamp))
 
     @staticmethod
-    def _exit_scope(scope: Any | None) -> None:
-        if scope is None:
+    def _detach_token(token: Any | None) -> None:
+        if token is None:
             return
         try:
-            scope.__exit__(None, None, None)
+            token.var.reset(token)
+        except ValueError as exc:
+            if "different Context" not in str(exc):
+                logger.debug("OTEL context detach failed.", exc_info=True)
+                return
+            old_value = {} if token.old_value is Token.MISSING else token.old_value
+            token.var.set(old_value)
+            logger.debug("OTEL context token restored from foreign context.")
         except Exception:
-            logger.debug("OTEL scope exit from foreign context.", exc_info=True)
+            logger.debug("OTEL context detach failed.", exc_info=True)
 
 
 def build_otel_recorder(
@@ -333,6 +341,7 @@ def _build_exporter(options: dict[str, Any], otel: Any) -> Any:
 def _import_otel() -> Any:
     try:
         from opentelemetry import trace
+        from opentelemetry import context as context_api
         from opentelemetry.exporter.otlp.proto.grpc.trace_exporter import (
             OTLPSpanExporter as GrpcOTLPSpanExporter,
         )
@@ -367,6 +376,7 @@ def _import_otel() -> Any:
         pass
 
     otel = OTel()
+    otel.context = context_api
     otel.trace = trace
     otel.BatchSpanProcessor = BatchSpanProcessor
     otel.ConsoleSpanExporter = ConsoleSpanExporter

--- a/docs/telemetry.md
+++ b/docs/telemetry.md
@@ -164,13 +164,14 @@ acceptable, and prefer `Telemetry.aclose()` in async applications.
 
 Do not move OTEL `record()` calls behind a background queue or worker thread.
 The recorder intentionally runs synchronously in the caller's thread/task so
-`trace.use_span(...)` attaches the AUTOMA span to the same OpenTelemetry context
-that auto-instrumented libraries such as `httpx`, `requests`, `botocore`, and
-model SDKs read from. If span start/end recording happens in a different worker
-context than the tool/model call, those auto-instrumented child spans will not
-inherit the AUTOMA `agent.turn` or `tool.call` parent span. Concurrent tool
-calls are supported when each span starts, runs, and ends inside its own asyncio
-task/thread context; do not start a span in one task and end it in another.
+`context.attach(trace.set_span_in_context(...))` attaches the AUTOMA span to the
+same OpenTelemetry context that auto-instrumented libraries such as `httpx`,
+`requests`, `botocore`, and model SDKs read from. If span start/end recording
+happens in a different worker context than the tool/model call, those
+auto-instrumented child spans will not inherit the AUTOMA `agent.turn` or
+`tool.call` parent span. Concurrent tool calls are supported when each span
+starts, runs, and ends inside its own asyncio task/thread context; do not start a
+span in one task and end it in another.
 
 ## Custom Recorders
 

--- a/tests/test_telemetry.py
+++ b/tests/test_telemetry.py
@@ -473,7 +473,7 @@ def test_otel_recorder_sets_current_span_context_in_caller_task(monkeypatch) -> 
 
 
 def test_otel_recorder_ends_span_when_scope_exits_from_foreign_context(
-    monkeypatch,
+    monkeypatch, caplog
 ) -> None:
     exporter = InMemorySpanExporter()
     monkeypatch.setattr(
@@ -522,6 +522,7 @@ def test_otel_recorder_ends_span_when_scope_exits_from_foreign_context(
     assert spans[0].context.trace_id == int(trace_id, 16)
     assert spans[0].context.span_id == int(span_id, 16)
     assert spans[0].status.status_code.name == "OK"
+    assert "Failed to detach context" not in caplog.text
 
 
 def test_otel_recorder_close_ends_all_spans_with_foreign_scope_contexts(


### PR DESCRIPTION
Fix OTEL foreign-context span cleanup

- replace trace.use_span scope handling with direct context attach tokens
- tolerate span end/close from a different contextvars context
- always end/export spans even when context cleanup is unusual
- avoid OpenTelemetry's noisy "Failed to detach context" error log
- document direct context attach behavior
- add regression coverage for foreign-context span end and recorder close