### PR TITLE
feat(a2a): support card-derived and custom subagent auth headers

### DIFF
--- a/automa_ai/agents/remote_agent.py
+++ b/automa_ai/agents/remote_agent.py
@@ -9,7 +9,7 @@ import re
 
 from google.protobuf.json_format import MessageToDict, ParseDict
 
-from a2a.client import Client, ClientConfig, create_client
+from a2a.client import Client, ClientCallContext, ClientConfig, create_client
 from a2a.helpers.proto_helpers import get_message_text, new_text_message
 from a2a.types import (
     AgentCard,
@@ -106,6 +106,7 @@ class SubAgentSpec:
     name: str
     description: str
     agent_card: AgentCard | dict[str, Any]
+    request_headers: dict[str, str] | None = None
 
     @property
     def tool_name(self) -> str:
@@ -262,6 +263,7 @@ def make_subagent_tool(
         agent_name=spec.tool_name,
         subagent_card=spec.resolved_agent_card,
         description=spec.description,
+        request_headers=spec.request_headers,
     )
 
     adapter = A2AToolAdapter(subagent=subagent, emit_event=emitter)
@@ -278,9 +280,7 @@ def make_subagent_tool(
         agent_card: AgentCard = adapter.subagent.agent_card
         context_id = get_subagent_context_id()
         if agent_card.capabilities.streaming:
-            async for chunk in adapter.stream(
-                delegated_task, context_id=context_id
-            ):
+            async for chunk in adapter.stream(delegated_task, context_id=context_id):
                 chunks.append(chunk)
         else:
             result = await adapter.run(delegated_task, context_id=context_id)
@@ -296,8 +296,7 @@ def make_subagent_tool(
             }
         return {
             "final": (
-                "No result produced by the subagent "
-                f"{adapter.subagent.agent_name}"
+                "No result produced by the subagent " f"{adapter.subagent.agent_name}"
             ),
             "chunks": "",
             "task_id": "",
@@ -319,6 +318,7 @@ class RemoteAgent(BaseAgent):
         agent_name: str,
         subagent_card: AgentCard,
         description: str,
+        request_headers: dict[str, str] | None = None,
     ):
         super().__init__(
             agent_name=agent_name,
@@ -327,6 +327,7 @@ class RemoteAgent(BaseAgent):
         )
 
         self._httpx_client = httpx.AsyncClient(timeout=httpx.Timeout(None))
+        self._request_headers = dict(request_headers or {})
         self.agent_card = subagent_card
         self._streaming_client: Client | None = None
         self._non_streaming_client: Client | None = None
@@ -348,11 +349,13 @@ class RemoteAgent(BaseAgent):
                     streaming=False,
                 ),
             )
-        return (
-            self._streaming_client
-            if streaming
-            else self._non_streaming_client
-        )
+        return self._streaming_client if streaming else self._non_streaming_client
+
+    def _request_context(self) -> ClientCallContext | None:
+        """Expose subagent credentials through the A2A client transport API."""
+        if not self._request_headers:
+            return None
+        return ClientCallContext(service_parameters=dict(self._request_headers))
 
     def _build_request(
         self,
@@ -384,9 +387,7 @@ class RemoteAgent(BaseAgent):
         if message_metadata:
             a2a_message.metadata.update(message_metadata)
 
-        return SendMessageRequest(
-            message=a2a_message
-        )
+        return SendMessageRequest(message=a2a_message)
 
     @staticmethod
     def _unwrap_response(
@@ -410,7 +411,6 @@ class RemoteAgent(BaseAgent):
         user_id: str | None = None,
         metadata: dict[str, Any] | None = None,
     ) -> Task | Message:
-        client = await self._get_client(streaming=False)
         request = self._build_request(
             message,
             context_id=context_id,
@@ -419,8 +419,13 @@ class RemoteAgent(BaseAgent):
             metadata=metadata,
         )
 
+        client = await self._get_client(streaming=False)
+
         last_response: Message | Task | None = None
-        async for chunk in client.send_message(request):
+        async for chunk in client.send_message(
+            request,
+            context=self._request_context(),
+        ):
             event = self._unwrap_response(chunk)
             if isinstance(event, (Message, Task)):
                 last_response = event
@@ -442,7 +447,6 @@ class RemoteAgent(BaseAgent):
         Message | Task | TaskStatusUpdateEvent | TaskArtifactUpdateEvent,
         None,
     ]:
-        client = await self._get_client(streaming=True)
         request = self._build_request(
             message,
             context_id=context_id,
@@ -451,7 +455,12 @@ class RemoteAgent(BaseAgent):
             metadata=metadata,
         )
 
-        async for chunk in client.send_message(request):
+        client = await self._get_client(streaming=True)
+
+        async for chunk in client.send_message(
+            request,
+            context=self._request_context(),
+        ):
             event = self._unwrap_response(chunk)
             if event is not None:
                 yield event

--- a/automa_ai/config/__init__.py
+++ b/automa_ai/config/__init__.py
@@ -1,6 +1,7 @@
 """Configuration models for automa_ai."""
 
 from automa_ai.config.blackboard import BlackboardConfig
+from automa_ai.config.a2a_auth import A2AClientAuthConfig
 from automa_ai.config.checkpointer import CheckpointerConfig
 from automa_ai.config.service import (
     ServiceAuthConfig,
@@ -18,6 +19,7 @@ from automa_ai.config.tools import ToolSpec, ToolsConfig
 __all__ = [
     "ToolSpec",
     "ToolsConfig",
+    "A2AClientAuthConfig",
     "BlackboardConfig",
     "CheckpointerConfig",
     "ServiceAuthConfig",

--- a/automa_ai/config/a2a_auth.py
+++ b/automa_ai/config/a2a_auth.py
@@ -1,0 +1,57 @@
+"""Outbound authentication configuration for remote A2A agents."""
+
+from __future__ import annotations
+
+from typing import Any, Literal
+
+from pydantic import BaseModel, ConfigDict, Field, SecretStr
+
+
+class A2AClientAuthConfig(BaseModel):
+    """Credentials an AUTOMA-AI client uses to call one remote A2A agent.
+
+    Credentials are intentionally configured separately from the Agent Card:
+    the card declares the authentication requirement, while deployments supply
+    the secret through environment-variable resolution or another secret store.
+    """
+
+    type: Literal["api_key"] = "api_key"
+    scheme: str = Field(min_length=1)
+    api_key: SecretStr
+
+    model_config = ConfigDict(extra="forbid")
+
+    def request_headers(self, agent_card: dict[str, Any]) -> dict[str, str]:
+        """Validate the card requirement and return the credential header."""
+        security_schemes = agent_card.get("securitySchemes")
+        if not isinstance(security_schemes, dict):
+            raise ValueError(
+                "Remote A2A agent card must declare securitySchemes when "
+                "subagent auth is configured."
+            )
+
+        declared_scheme = security_schemes.get(self.scheme)
+        if not isinstance(declared_scheme, dict):
+            raise ValueError(
+                f"Remote A2A agent card does not declare security scheme "
+                f"'{self.scheme}'."
+            )
+
+        api_key_scheme = declared_scheme.get("apiKeySecurityScheme")
+        if not isinstance(api_key_scheme, dict):
+            raise ValueError(
+                f"A2A security scheme '{self.scheme}' is not an API-key scheme."
+            )
+
+        if api_key_scheme.get("location") != "header":
+            raise ValueError(
+                f"A2A API-key scheme '{self.scheme}' must use location 'header'."
+            )
+
+        header_name = api_key_scheme.get("name")
+        if not isinstance(header_name, str) or not header_name.strip():
+            raise ValueError(
+                f"A2A API-key scheme '{self.scheme}' must declare a header name."
+            )
+
+        return {header_name: self.api_key.get_secret_value()}

--- a/automa_ai/config/a2a_auth.py
+++ b/automa_ai/config/a2a_auth.py
@@ -54,4 +54,14 @@ class A2AClientAuthConfig(BaseModel):
                 f"A2A API-key scheme '{self.scheme}' must declare a header name."
             )
 
-        return {header_name: self.api_key.get_secret_value()}
+        api_key = self.api_key.get_secret_value()
+        if "\r" in header_name or "\n" in header_name:
+            raise ValueError(
+                f"A2A API-key scheme '{self.scheme}' declares an invalid header name."
+            )
+        if "\r" in api_key or "\n" in api_key:
+            raise ValueError(
+                "A2A API key must not contain carriage returns or newlines."
+            )
+
+        return {header_name: api_key}

--- a/automa_ai/config/agent_spec.py
+++ b/automa_ai/config/agent_spec.py
@@ -177,7 +177,12 @@ class SubAgentYamlSpec(BaseModel):
                 raise ValueError(
                     "subagent request_headers contains an invalid header name."
                 )
-            headers[name] = value.get_secret_value()
+            header_value = value.get_secret_value()
+            if "\r" in header_value or "\n" in header_value:
+                raise ValueError(
+                    "subagent request_headers contains an invalid header value."
+                )
+            headers[name] = header_value
         return headers
 
     def to_subagent_spec(self, *, base_dir: Path) -> SubAgentSpec:

--- a/automa_ai/config/agent_spec.py
+++ b/automa_ai/config/agent_spec.py
@@ -14,13 +14,14 @@ import re
 from typing import Any, Literal, TypeAlias
 
 import yaml
-from pydantic import BaseModel, ConfigDict, Field, model_validator
+from pydantic import BaseModel, ConfigDict, Field, SecretStr, model_validator
 
 from automa_ai.agents import GenericAgentType, GenericLLM
 from automa_ai.agents.agent_factory import AgentFactory
 from automa_ai.agents.remote_agent import SubAgentSpec
 from automa_ai.common.agent_registry import A2AAgentServer
 from automa_ai.common.mcp_registry import MCPServerConfig
+from automa_ai.config.a2a_auth import A2AClientAuthConfig
 from automa_ai.config.service import ServiceConfig
 
 
@@ -121,6 +122,8 @@ class SubAgentYamlSpec(BaseModel):
     agent_card: dict[str, Any] | None = None
     spec_path: str | None = None
     card_path: str | None = None
+    auth: A2AClientAuthConfig | None = None
+    request_headers: dict[str, SecretStr] | None = None
 
     @model_validator(mode="after")
     def _validate_single_card_source(self) -> "SubAgentYamlSpec":
@@ -133,10 +136,16 @@ class SubAgentYamlSpec(BaseModel):
             raise ValueError(
                 "subagent requires exactly one of 'agent_card', 'spec_path', or 'card_path'."
             )
+        if self.auth is not None and self.request_headers is not None:
+            raise ValueError(
+                "subagent may define either auth or request_headers, not both."
+            )
         return self
 
     def resolve_agent_card(self, *, base_dir: Path) -> dict[str, Any]:
         """Resolve the subagent card from an inline card, YAML spec, or JSON card file."""
+        # TODO: Support remote Agent Card discovery from
+        # /.well-known/agent-card.json for subagents configured by URL.
         if self.agent_card is not None:
             card = deepcopy(self.agent_card)
             _validate_a2a_card(card, label="subagent.agent_card")
@@ -151,6 +160,25 @@ class SubAgentYamlSpec(BaseModel):
         card = json.loads(card_path.read_text(encoding="utf-8"))
         _validate_a2a_card(card, label=f"subagent.card_path '{card_path}'")
         return card
+
+    def resolve_request_headers(
+        self,
+        agent_card: dict[str, Any],
+    ) -> dict[str, str] | None:
+        """Build either card-derived or explicitly configured request headers."""
+        if self.auth is not None:
+            return self.auth.request_headers(agent_card)
+        if self.request_headers is None:
+            return None
+
+        headers: dict[str, str] = {}
+        for name, value in self.request_headers.items():
+            if not name.strip() or "\r" in name or "\n" in name:
+                raise ValueError(
+                    "subagent request_headers contains an invalid header name."
+                )
+            headers[name] = value.get_secret_value()
+        return headers
 
     def to_subagent_spec(self, *, base_dir: Path) -> SubAgentSpec:
         """Convert the YAML subagent entry into the runtime delegation spec."""
@@ -169,6 +197,7 @@ class SubAgentYamlSpec(BaseModel):
             name=name,
             description=description,
             agent_card=agent_card,
+            request_headers=self.resolve_request_headers(agent_card),
         )
 
 
@@ -374,6 +403,8 @@ def _should_resolve_env_placeholders(path: tuple[str, ...]) -> bool:
     """Return true for YAML keys intended to carry secrets or credentials."""
     if not path:
         return False
+    if "request_headers" in path:
+        return True
     key = path[-1].lower()
     return key in _ENV_PLACEHOLDER_KEY_NAMES or key.endswith(
         _ENV_PLACEHOLDER_KEY_SUFFIXES

--- a/docs/yaml_agent_spec.md
+++ b/docs/yaml_agent_spec.md
@@ -517,6 +517,59 @@ Resolved subagent cards must use the A2A 1.0 `supportedInterfaces` shape. The
 loader validates cards loaded from `spec_path`, `card_path`, and inline
 `agent_card` entries before creating runtime `SubAgentSpec` objects.
 
+#### API-key authentication for a remote subagent
+
+Use `auth` to send an API key to one remote A2A agent. This is client-side
+configuration and is separate from `service.auth`, which protects requests
+arriving at the current agent server. The remote Agent Card must declare the
+referenced API-key scheme with `location: header` and a header `name`;
+credentials must be supplied through an environment variable, never in the
+card.
+
+```yaml
+subagents:
+  - name: CE Expert
+    card_path: ./agents/ce_expert_remote_card.json
+    auth:
+      type: api_key
+      scheme: permitce_api_key
+      api_key: ${CE_EXPERT_API_KEY}
+```
+
+For example, the referenced remote card declares the gateway contract:
+
+```yaml
+securitySchemes:
+  permitce_api_key:
+    apiKeySecurityScheme:
+      location: header
+      name: x-api-key
+```
+
+AUTOMA-AI validates the scheme during YAML loading and adds the declared header
+to every streaming and non-streaming A2A request. It does not copy the secret
+into A2A task metadata, prompts, or the Agent Card.
+
+#### Custom request headers for a gateway or legacy service
+
+Use `request_headers` when a remote service requires a gateway-specific
+authentication contract that is not declared in its Agent Card. This remains a
+native A2A invocation; AUTOMA-AI passes the configured values to the A2A client
+as transport headers. `auth` and `request_headers` are mutually exclusive.
+
+```yaml
+subagents:
+  - name: CE Expert
+    card_path: ./agents/ce_expert_remote_card.json
+    request_headers:
+      x-api-key: ${CE_EXPERT_API_KEY}
+      x-gateway-client: ce-backend
+```
+
+Environment placeholders are resolved for all `request_headers` values. Header
+values are treated as secrets and are not copied into task metadata or prompts.
+
+
 ### `tools`
 
 Optional object or list passed through to `AgentFactory(..., tools_config=...)`.

--- a/docs/yaml_agent_spec.md
+++ b/docs/yaml_agent_spec.md
@@ -522,9 +522,9 @@ loader validates cards loaded from `spec_path`, `card_path`, and inline
 Use `auth` to send an API key to one remote A2A agent. This is client-side
 configuration and is separate from `service.auth`, which protects requests
 arriving at the current agent server. The remote Agent Card must declare the
-referenced API-key scheme with `location: header` and a header `name`;
-credentials must be supplied through an environment variable, never in the
-card.
+referenced API-key scheme with `location: header` and a header `name`.
+Use an environment variable rather than a literal value to avoid committing
+credentials to source control or the card.
 
 ```yaml
 subagents:

--- a/tests/test_a2a_client_auth.py
+++ b/tests/test_a2a_client_auth.py
@@ -56,6 +56,30 @@ def test_api_key_auth_rejects_card_without_matching_scheme() -> None:
         auth.request_headers(card)
 
 
+@pytest.mark.parametrize(
+    ("header_name", "api_key", "match"),
+    [
+        ("x-api-key\r\nx-injected: value", "test-api-key", "invalid header name"),
+        ("x-api-key", "test-api-key\r\nx-injected: value", "must not contain"),
+    ],
+)
+def test_api_key_auth_rejects_header_injection_values(
+    header_name: str,
+    api_key: str,
+    match: str,
+) -> None:
+    card = _remote_card()
+    card["securitySchemes"]["permitce_api_key"]["apiKeySecurityScheme"][
+        "name"
+    ] = header_name
+
+    with pytest.raises(ValueError, match=match):
+        A2AClientAuthConfig(
+            scheme="permitce_api_key",
+            api_key=api_key,
+        ).request_headers(card)
+
+
 @pytest.mark.asyncio
 async def test_remote_agent_passes_configured_headers_through_a2a_context() -> None:
     agent = RemoteAgent(
@@ -209,3 +233,41 @@ subagents:
       x-api-key: test-api-key
 """
         )
+
+
+def test_custom_request_headers_reject_header_injection_value() -> None:
+    spec = YamlAgentSpec.from_yaml_text(
+        """
+spec_version: v1
+agent_card:
+  name: Coordinator
+  description: Coordinates remote agents.
+  version: 1.0.0
+  defaultInputModes: [text]
+  defaultOutputModes: [text]
+  capabilities: {streaming: true}
+  supportedInterfaces:
+    - url: http://localhost:32123
+      protocolBinding: JSONRPC
+      protocolVersion: "1.0"
+instructions: {text: Coordinate the request.}
+model: {provider: ollama, name: llama3.1:8b}
+subagents:
+  - agent_card:
+      name: CE Expert
+      description: Remote CE analysis.
+      version: 1.0.0
+      defaultInputModes: [text]
+      defaultOutputModes: [text]
+      capabilities: {streaming: true}
+      supportedInterfaces:
+        - url: https://example.com/ce-expert/invoke/
+          protocolBinding: JSONRPC
+          protocolVersion: "1.0"
+    request_headers:
+      x-api-key: "test-api-key\\r\\nx-injected: value"
+"""
+    )
+
+    with pytest.raises(ValueError, match="invalid header value"):
+        spec.to_factory_kwargs()

--- a/tests/test_a2a_client_auth.py
+++ b/tests/test_a2a_client_auth.py
@@ -1,0 +1,211 @@
+from __future__ import annotations
+
+import pytest
+from google.protobuf.json_format import ParseDict
+
+from a2a.types import AgentCard
+from automa_ai.agents.remote_agent import RemoteAgent
+from automa_ai.config.a2a_auth import A2AClientAuthConfig
+from automa_ai.config.agent_spec import YamlAgentSpec
+
+
+def _remote_card() -> dict:
+    return {
+        "name": "Remote CE Expert",
+        "description": "A remote A2A agent protected by an API key.",
+        "version": "1.0.0",
+        "defaultInputModes": ["text"],
+        "defaultOutputModes": ["text"],
+        "capabilities": {"streaming": True},
+        "supportedInterfaces": [
+            {
+                "url": "https://example.com/ce-expert/invoke/",
+                "protocolBinding": "JSONRPC",
+                "protocolVersion": "1.0",
+            }
+        ],
+        "securitySchemes": {
+            "permitce_api_key": {
+                "apiKeySecurityScheme": {
+                    "location": "header",
+                    "name": "x-api-key",
+                }
+            }
+        },
+    }
+
+
+def test_api_key_auth_uses_header_declared_by_agent_card() -> None:
+    auth = A2AClientAuthConfig(
+        scheme="permitce_api_key",
+        api_key="test-api-key",
+    )
+
+    assert auth.request_headers(_remote_card()) == {"x-api-key": "test-api-key"}
+
+
+def test_api_key_auth_rejects_card_without_matching_scheme() -> None:
+    auth = A2AClientAuthConfig(
+        scheme="permitce_api_key",
+        api_key="test-api-key",
+    )
+    card = _remote_card()
+    card["securitySchemes"] = {}
+
+    with pytest.raises(ValueError, match="does not declare security scheme"):
+        auth.request_headers(card)
+
+
+@pytest.mark.asyncio
+async def test_remote_agent_passes_configured_headers_through_a2a_context() -> None:
+    agent = RemoteAgent(
+        agent_name="remote_ce_expert",
+        subagent_card=ParseDict(_remote_card(), AgentCard()),
+        description="Remote CE expert.",
+        request_headers={"x-api-key": "test-api-key"},
+    )
+    try:
+        context = agent._request_context()
+        assert context is not None
+        assert context.service_parameters == {"x-api-key": "test-api-key"}
+    finally:
+        await agent.close()
+
+
+def test_yaml_subagent_resolves_api_key_auth_from_environment(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("CE_EXPERT_API_KEY", "test-api-key")
+    spec = YamlAgentSpec.from_yaml_text(
+        """
+spec_version: v1
+agent_card:
+  name: Coordinator
+  description: Coordinates remote agents.
+  version: 1.0.0
+  defaultInputModes: [text]
+  defaultOutputModes: [text]
+  capabilities: {streaming: true}
+  supportedInterfaces:
+    - url: http://localhost:32123
+      protocolBinding: JSONRPC
+      protocolVersion: "1.0"
+instructions: {text: Coordinate the request.}
+model: {provider: ollama, name: llama3.1:8b}
+subagents:
+  - agent_card:
+      name: CE Expert
+      description: Remote CE analysis.
+      version: 1.0.0
+      defaultInputModes: [text]
+      defaultOutputModes: [text]
+      capabilities: {streaming: true}
+      supportedInterfaces:
+        - url: https://example.com/ce-expert/invoke/
+          protocolBinding: JSONRPC
+          protocolVersion: "1.0"
+      securitySchemes:
+        permitce_api_key:
+          apiKeySecurityScheme:
+            location: header
+            name: x-api-key
+    auth:
+      type: api_key
+      scheme: permitce_api_key
+      api_key: ${CE_EXPERT_API_KEY}
+"""
+    )
+
+    subagent = spec.to_factory_kwargs()["subagent_config"][0]
+
+    assert subagent.request_headers == {"x-api-key": "test-api-key"}
+
+
+def test_yaml_subagent_resolves_custom_request_headers_from_environment(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("CE_EXPERT_API_KEY", "test-api-key")
+    spec = YamlAgentSpec.from_yaml_text(
+        """
+spec_version: v1
+agent_card:
+  name: Coordinator
+  description: Coordinates remote agents.
+  version: 1.0.0
+  defaultInputModes: [text]
+  defaultOutputModes: [text]
+  capabilities: {streaming: true}
+  supportedInterfaces:
+    - url: http://localhost:32123
+      protocolBinding: JSONRPC
+      protocolVersion: "1.0"
+instructions: {text: Coordinate the request.}
+model: {provider: ollama, name: llama3.1:8b}
+subagents:
+  - agent_card:
+      name: CE Expert
+      description: Remote CE analysis.
+      version: 1.0.0
+      defaultInputModes: [text]
+      defaultOutputModes: [text]
+      capabilities: {streaming: true}
+      supportedInterfaces:
+        - url: https://example.com/ce-expert/invoke/
+          protocolBinding: JSONRPC
+          protocolVersion: "1.0"
+    request_headers:
+      x-api-key: ${CE_EXPERT_API_KEY}
+      x-gateway-client: ce-backend
+"""
+    )
+
+    subagent = spec.to_factory_kwargs()["subagent_config"][0]
+
+    assert subagent.request_headers == {
+        "x-api-key": "test-api-key",
+        "x-gateway-client": "ce-backend",
+    }
+
+
+def test_yaml_subagent_rejects_auth_and_custom_request_headers() -> None:
+    with pytest.raises(ValueError, match="either auth or request_headers"):
+        YamlAgentSpec.from_yaml_text(
+            """
+spec_version: v1
+agent_card:
+  name: Coordinator
+  description: Coordinates remote agents.
+  version: 1.0.0
+  defaultInputModes: [text]
+  defaultOutputModes: [text]
+  capabilities: {streaming: true}
+  supportedInterfaces:
+    - url: http://localhost:32123
+      protocolBinding: JSONRPC
+      protocolVersion: "1.0"
+instructions: {text: Coordinate the request.}
+model: {provider: ollama, name: llama3.1:8b}
+subagents:
+  - agent_card:
+      name: CE Expert
+      description: Remote CE analysis.
+      version: 1.0.0
+      defaultInputModes: [text]
+      defaultOutputModes: [text]
+      capabilities: {streaming: true}
+      supportedInterfaces:
+        - url: https://example.com/ce-expert/invoke/
+          protocolBinding: JSONRPC
+          protocolVersion: "1.0"
+      securitySchemes:
+        permitce_api_key:
+          apiKeySecurityScheme:
+            location: header
+            name: x-api-key
+    auth:
+      scheme: permitce_api_key
+      api_key: test-api-key
+    request_headers:
+      x-api-key: test-api-key
+"""
+        )


### PR DESCRIPTION
## Summary
Adds configurable outbound authentication headers for remote AUTOMA-AI A2A subagents.
Supports card-derived API-key authentication through `subagents[].auth`.
Supports explicit gateway-specific headers through `subagents[].request_headers`.
Enforces that the two configuration paths are mutually exclusive.
Preserves native A2A invocation and streaming for both paths.
Adds a TODO for future remote Agent Card discovery via .well-known/agent-card.json.
## Validation
`46 passed` across focused authentication, YAML agent-spec, and service-auth tests.
Black and whitespace checks passed.