### PR TITLE
update user id in sub agents.

### DIFF
--- a/automa_ai/agents/langgraph_chatagent.py
+++ b/automa_ai/agents/langgraph_chatagent.py
@@ -24,6 +24,8 @@ from automa_ai.agents.remote_agent import (
     StreamEvent,
     set_subagent_context_id,
     reset_subagent_context_id,
+    set_subagent_user_id,
+    reset_subagent_user_id,
     set_subagent_emitter,
     reset_subagent_emitter,
 )
@@ -499,6 +501,7 @@ class GenericLangGraphChatAgent(BaseAgent):
                     },
                 )
                 context_token = set_subagent_context_id(turn.context_id)
+                user_id_token = set_subagent_user_id(turn.user_id)
                 emitter_token = set_subagent_emitter(emit_subagent_event)
                 try:
                     response = await self.graph.ainvoke(inputs, config)
@@ -528,6 +531,7 @@ class GenericLangGraphChatAgent(BaseAgent):
                     raise
                 finally:
                     reset_subagent_emitter(emitter_token)
+                    reset_subagent_user_id(user_id_token)
                     reset_subagent_context_id(context_token)
         finally:
             if telemetry_token is not None:
@@ -651,6 +655,7 @@ class GenericLangGraphChatAgent(BaseAgent):
                     tool_activity_started = False
                     human_message_queued = False
                     context_token = set_subagent_context_id(context_id)
+                    user_id_token = set_subagent_user_id(user_id)
                     emitter_token = set_subagent_emitter(emit_subagent_event)
                     try:
                         async for chunk in self.graph.astream(
@@ -858,6 +863,7 @@ class GenericLangGraphChatAgent(BaseAgent):
                         break
                     finally:
                         reset_subagent_emitter(emitter_token)
+                        reset_subagent_user_id(user_id_token)
                         reset_subagent_context_id(context_token)
             except TokenBudgetExceededError as exc:
                 logger.info(

--- a/automa_ai/agents/react_langgraph_agent.py
+++ b/automa_ai/agents/react_langgraph_agent.py
@@ -15,6 +15,8 @@ from automa_ai.agents.remote_agent import (
     make_subagent_tool,
     StreamEvent,
     build_subagent_delegation_instruction,
+    reset_subagent_user_id,
+    set_subagent_user_id,
 )
 from automa_ai.common.base_agent import BaseAgent
 from automa_ai.common.response_parser import extract_and_parse_json
@@ -138,7 +140,14 @@ class GenericLangGraphReactAgent(BaseAgent):
 
         if not self.graph:
             await self.init_graph(emitter)
-        response = await self.graph.ainvoke({"messages": [("user", query)]}, config)
+        user_id_token = set_subagent_user_id(user_id)
+        try:
+            response = await self.graph.ainvoke(
+                {"messages": [("user", query)]},
+                config,
+            )
+        finally:
+            reset_subagent_user_id(user_id_token)
         return response
 
     async def stream(
@@ -188,9 +197,22 @@ class GenericLangGraphReactAgent(BaseAgent):
         )
         if not self.graph:
             await self.init_graph(emitter)
+
+        async def graph_stream():
+            user_id_token = set_subagent_user_id(user_id)
+            try:
+                async for graph_chunk in self.graph.astream(
+                    inputs,
+                    config,
+                    stream_mode="updates",
+                ):
+                    yield graph_chunk
+            finally:
+                reset_subagent_user_id(user_id_token)
+
         # seen_messages = set()
         # Collect all streaming messages first
-        async for chunk in self.graph.astream(inputs, config, stream_mode="updates"):
+        async for chunk in graph_stream():
             # surface local tool/subagent streaming
             while not subagent_event_queue.empty():
                 event = subagent_event_queue.get_nowait()

--- a/automa_ai/agents/react_langgraph_agent.py
+++ b/automa_ai/agents/react_langgraph_agent.py
@@ -15,7 +15,9 @@ from automa_ai.agents.remote_agent import (
     make_subagent_tool,
     StreamEvent,
     build_subagent_delegation_instruction,
+    reset_subagent_context_id,
     reset_subagent_user_id,
+    set_subagent_context_id,
     set_subagent_user_id,
 )
 from automa_ai.common.base_agent import BaseAgent
@@ -140,6 +142,7 @@ class GenericLangGraphReactAgent(BaseAgent):
 
         if not self.graph:
             await self.init_graph(emitter)
+        context_id_token = set_subagent_context_id(context_id)
         user_id_token = set_subagent_user_id(user_id)
         try:
             response = await self.graph.ainvoke(
@@ -148,6 +151,7 @@ class GenericLangGraphReactAgent(BaseAgent):
             )
         finally:
             reset_subagent_user_id(user_id_token)
+            reset_subagent_context_id(context_id_token)
         return response
 
     async def stream(
@@ -206,6 +210,7 @@ class GenericLangGraphReactAgent(BaseAgent):
             ).__aiter__()
             try:
                 while True:
+                    context_id_token = set_subagent_context_id(context_id)
                     user_id_token = set_subagent_user_id(user_id)
                     try:
                         graph_chunk = await anext(graph_iterator)
@@ -213,8 +218,9 @@ class GenericLangGraphReactAgent(BaseAgent):
                         return
                     finally:
                         # Reset before yielding to the caller so an early-stop
-                        # cannot leave identity scoped to this request.
+                        # cannot leave request context scoped to this request.
                         reset_subagent_user_id(user_id_token)
+                        reset_subagent_context_id(context_id_token)
                     yield graph_chunk
             finally:
                 close = getattr(graph_iterator, "aclose", None)

--- a/automa_ai/agents/react_langgraph_agent.py
+++ b/automa_ai/agents/react_langgraph_agent.py
@@ -199,16 +199,27 @@ class GenericLangGraphReactAgent(BaseAgent):
             await self.init_graph(emitter)
 
         async def graph_stream():
-            user_id_token = set_subagent_user_id(user_id)
+            graph_iterator = self.graph.astream(
+                inputs,
+                config,
+                stream_mode="updates",
+            ).__aiter__()
             try:
-                async for graph_chunk in self.graph.astream(
-                    inputs,
-                    config,
-                    stream_mode="updates",
-                ):
+                while True:
+                    user_id_token = set_subagent_user_id(user_id)
+                    try:
+                        graph_chunk = await anext(graph_iterator)
+                    except StopAsyncIteration:
+                        return
+                    finally:
+                        # Reset before yielding to the caller so an early-stop
+                        # cannot leave identity scoped to this request.
+                        reset_subagent_user_id(user_id_token)
                     yield graph_chunk
             finally:
-                reset_subagent_user_id(user_id_token)
+                close = getattr(graph_iterator, "aclose", None)
+                if close is not None:
+                    await close()
 
         # seen_messages = set()
         # Collect all streaming messages first

--- a/automa_ai/agents/remote_agent.py
+++ b/automa_ai/agents/remote_agent.py
@@ -406,14 +406,16 @@ class RemoteAgent(BaseAgent):
     ) -> SendMessageRequest:
         message_metadata = dict(metadata or {})
         if user_id is not None:
-            message_metadata.setdefault("user_id", user_id)
-            # A2A metadata permits application-defined keys. Retain the
-            # framework's snake_case convention and include the camelCase form
+            # `user_id` originates from the authenticated parent request, so it
+            # must not be overridden by arbitrary caller-provided metadata.
+            message_metadata["user_id"] = user_id
+            # A2A metadata permits application-defined keys. Keep the
+            # framework's snake_case convention and provide the camelCase form
             # expected by CE Expert and other browser/API clients.
-            message_metadata.setdefault("userId", user_id)
+            message_metadata["userId"] = user_id
         # A2A metadata is the cross-process boundary for subagent calls. Carry
-        # only trace identifiers here; message/tool payloads stay in events and
-        # are sanitized by the recorder.
+        # authenticated identity and trace identifiers here; message/tool
+        # payloads stay in events and are sanitized by the recorder.
         trace_id = current_trace_id()
         span_id = current_span_id()
         if trace_id is not None:

--- a/automa_ai/agents/remote_agent.py
+++ b/automa_ai/agents/remote_agent.py
@@ -33,6 +33,10 @@ _subagent_context_id: ContextVar[str | None] = ContextVar(
     "subagent_context_id",
     default=None,
 )
+_subagent_user_id: ContextVar[str | None] = ContextVar(
+    "subagent_user_id",
+    default=None,
+)
 _subagent_emitter: ContextVar[Callable[[Any], Awaitable[None]] | None] = ContextVar(
     "subagent_emitter",
     default=None,
@@ -49,6 +53,18 @@ def reset_subagent_context_id(token: Any) -> None:
 
 def get_subagent_context_id() -> str | None:
     return _subagent_context_id.get()
+
+
+def set_subagent_user_id(user_id: str | None) -> Any:
+    return _subagent_user_id.set(user_id)
+
+
+def reset_subagent_user_id(token: Any) -> None:
+    _subagent_user_id.reset(token)
+
+
+def get_subagent_user_id() -> str | None:
+    return _subagent_user_id.get()
 
 
 def set_subagent_emitter(emitter: Callable[[Any], Awaitable[None]]) -> Any:
@@ -149,8 +165,17 @@ class A2AToolAdapter:
         if active_emitter:
             await active_emitter(event)
 
-    async def run(self, task: str, context_id: str | None = None) -> A2AToolResult:
-        a2a_result = await self.subagent.invoke(task, context_id=context_id)
+    async def run(
+        self,
+        task: str,
+        context_id: str | None = None,
+        user_id: str | None = None,
+    ) -> A2AToolResult:
+        a2a_result = await self.subagent.invoke(
+            task,
+            context_id=context_id,
+            user_id=user_id,
+        )
         chunks: list[str] = []
 
         if isinstance(a2a_result, Message):
@@ -205,9 +230,14 @@ class A2AToolAdapter:
         self,
         task: str,
         context_id: str | None = None,
+        user_id: str | None = None,
     ) -> AsyncIterable[A2AToolResult]:
         chunks: list[str] = []
-        async for chunk in self.subagent.stream(task, context_id=context_id):
+        async for chunk in self.subagent.stream(
+            task,
+            context_id=context_id,
+            user_id=user_id,
+        ):
             if isinstance(chunk, TaskStatusUpdateEvent):
                 if chunk.status.state == TaskState.TASK_STATE_COMPLETED:
                     continue
@@ -279,11 +309,20 @@ def make_subagent_tool(
             )
         agent_card: AgentCard = adapter.subagent.agent_card
         context_id = get_subagent_context_id()
+        user_id = get_subagent_user_id()
         if agent_card.capabilities.streaming:
-            async for chunk in adapter.stream(delegated_task, context_id=context_id):
+            async for chunk in adapter.stream(
+                delegated_task,
+                context_id=context_id,
+                user_id=user_id,
+            ):
                 chunks.append(chunk)
         else:
-            result = await adapter.run(delegated_task, context_id=context_id)
+            result = await adapter.run(
+                delegated_task,
+                context_id=context_id,
+                user_id=user_id,
+            )
             chunks.append(result)
 
         result = chunks[-1] if chunks else None
@@ -368,6 +407,10 @@ class RemoteAgent(BaseAgent):
         message_metadata = dict(metadata or {})
         if user_id is not None:
             message_metadata.setdefault("user_id", user_id)
+            # A2A metadata permits application-defined keys. Retain the
+            # framework's snake_case convention and include the camelCase form
+            # expected by CE Expert and other browser/API clients.
+            message_metadata.setdefault("userId", user_id)
         # A2A metadata is the cross-process boundary for subagent calls. Carry
         # only trace identifiers here; message/tool payloads stay in events and
         # are sanitized by the recorder.

--- a/tests/test_a2a_client_auth.py
+++ b/tests/test_a2a_client_auth.py
@@ -179,6 +179,34 @@ async def test_remote_agent_includes_user_id_metadata() -> None:
     assert metadata == {"user_id": "user-456", "userId": "user-456"}
 
 
+@pytest.mark.asyncio
+async def test_remote_agent_user_id_overrides_caller_metadata() -> None:
+    agent = RemoteAgent(
+        agent_name="remote_ce_expert",
+        subagent_card=ParseDict(_remote_card(), AgentCard()),
+        description="Remote CE expert.",
+    )
+    try:
+        request = agent._build_request(
+            "Analyze the project.",
+            user_id="trusted-user",
+            metadata={
+                "user_id": "spoofed-user",
+                "userId": "spoofed-user",
+                "request_source": "test",
+            },
+        )
+        metadata = MessageToDict(request.message.metadata)
+    finally:
+        await agent.close()
+
+    assert metadata == {
+        "user_id": "trusted-user",
+        "userId": "trusted-user",
+        "request_source": "test",
+    }
+
+
 def test_yaml_subagent_resolves_api_key_auth_from_environment(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/test_a2a_client_auth.py
+++ b/tests/test_a2a_client_auth.py
@@ -164,6 +164,57 @@ async def test_remote_subagent_tool_forwards_parent_user_id(
 
 
 @pytest.mark.asyncio
+async def test_remote_subagent_tool_forwards_parent_user_id_non_streaming(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured: dict[str, str | None] = {}
+
+    async def capture_run(
+        self: A2AToolAdapter,
+        task: str,
+        *,
+        context_id: str | None = None,
+        user_id: str | None = None,
+    ):
+        captured.update(
+            task=task,
+            context_id=context_id,
+            user_id=user_id,
+        )
+
+        class Result:
+            final = ""
+            chunks: list[str] = []
+            task_id = ""
+
+        return Result()
+
+    monkeypatch.setattr(A2AToolAdapter, "run", capture_run)
+    card = _remote_card()
+    card["capabilities"]["streaming"] = False
+    tool = make_subagent_tool(
+        SubAgentSpec(
+            name="Remote CE Expert",
+            description="Remote CE expert.",
+            agent_card=card,
+        )
+    )
+    context_token = set_subagent_context_id("session-123")
+    user_token = set_subagent_user_id("user-456")
+    try:
+        await tool.ainvoke({"task": "Analyze the project."})
+    finally:
+        reset_subagent_user_id(user_token)
+        reset_subagent_context_id(context_token)
+
+    assert captured == {
+        "task": "Analyze the project.",
+        "context_id": "session-123",
+        "user_id": "user-456",
+    }
+
+
+@pytest.mark.asyncio
 async def test_remote_agent_includes_user_id_metadata() -> None:
     agent = RemoteAgent(
         agent_name="remote_ce_expert",

--- a/tests/test_a2a_client_auth.py
+++ b/tests/test_a2a_client_auth.py
@@ -1,10 +1,19 @@
 from __future__ import annotations
 
 import pytest
-from google.protobuf.json_format import ParseDict
+from google.protobuf.json_format import MessageToDict, ParseDict
 
 from a2a.types import AgentCard
-from automa_ai.agents.remote_agent import RemoteAgent
+from automa_ai.agents.remote_agent import (
+    A2AToolAdapter,
+    RemoteAgent,
+    SubAgentSpec,
+    make_subagent_tool,
+    reset_subagent_context_id,
+    reset_subagent_user_id,
+    set_subagent_context_id,
+    set_subagent_user_id,
+)
 from automa_ai.config.a2a_auth import A2AClientAuthConfig
 from automa_ai.config.agent_spec import SubAgentYamlSpec, YamlAgentSpec
 
@@ -108,6 +117,66 @@ async def test_remote_agent_passes_configured_headers_through_a2a_context() -> N
         assert context.service_parameters == {"x-api-key": "test-api-key"}
     finally:
         await agent.close()
+
+
+@pytest.mark.asyncio
+async def test_remote_subagent_tool_forwards_parent_user_id(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured: dict[str, str | None] = {}
+
+    async def capture_stream(
+        self: A2AToolAdapter,
+        task: str,
+        *,
+        context_id: str | None = None,
+        user_id: str | None = None,
+    ):
+        captured.update(
+            task=task,
+            context_id=context_id,
+            user_id=user_id,
+        )
+        if False:
+            yield None
+
+    monkeypatch.setattr(A2AToolAdapter, "stream", capture_stream)
+    tool = make_subagent_tool(
+        SubAgentSpec(
+            name="Remote CE Expert",
+            description="Remote CE expert.",
+            agent_card=_remote_card(),
+        )
+    )
+    context_token = set_subagent_context_id("session-123")
+    user_token = set_subagent_user_id("user-456")
+    try:
+        await tool.ainvoke({"task": "Analyze the project."})
+    finally:
+        reset_subagent_user_id(user_token)
+        reset_subagent_context_id(context_token)
+
+    assert captured == {
+        "task": "Analyze the project.",
+        "context_id": "session-123",
+        "user_id": "user-456",
+    }
+
+
+@pytest.mark.asyncio
+async def test_remote_agent_includes_user_id_metadata() -> None:
+    agent = RemoteAgent(
+        agent_name="remote_ce_expert",
+        subagent_card=ParseDict(_remote_card(), AgentCard()),
+        description="Remote CE expert.",
+    )
+    try:
+        request = agent._build_request("Analyze the project.", user_id="user-456")
+        metadata = MessageToDict(request.message.metadata)
+    finally:
+        await agent.close()
+
+    assert metadata == {"user_id": "user-456", "userId": "user-456"}
 
 
 def test_yaml_subagent_resolves_api_key_auth_from_environment(

--- a/tests/test_react_subagent_identity.py
+++ b/tests/test_react_subagent_identity.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import pytest
+from langchain_core.messages import AIMessage
 
 from automa_ai.agents.react_langgraph_agent import GenericLangGraphReactAgent
 from automa_ai.agents.remote_agent import get_subagent_user_id
@@ -57,3 +58,35 @@ async def test_react_agent_stream_scopes_user_id_for_subagent_tools() -> None:
 
     assert captured == {"user_id": "user-456"}
     assert get_subagent_user_id() is None
+
+
+@pytest.mark.asyncio
+async def test_react_agent_stream_resets_user_id_before_early_stop() -> None:
+    captured: dict[str, str | None] = {}
+
+    class Graph:
+        async def astream(self, inputs, config, stream_mode):
+            captured["user_id"] = get_subagent_user_id()
+            yield {
+                "model": {
+                    "messages": [
+                        AIMessage(content='{"status": "completed"}'),
+                    ]
+                }
+            }
+
+    agent = _agent()
+    agent.graph = Graph()
+    stream = agent.stream(
+        "Analyze the project.",
+        "session-123",
+        "task-123",
+        user_id="user-456",
+    )
+
+    terminal_item = await anext(stream)
+
+    assert terminal_item["is_task_complete"] is True
+    assert captured == {"user_id": "user-456"}
+    assert get_subagent_user_id() is None
+    await stream.aclose()

--- a/tests/test_react_subagent_identity.py
+++ b/tests/test_react_subagent_identity.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+import pytest
+
+from automa_ai.agents.react_langgraph_agent import GenericLangGraphReactAgent
+from automa_ai.agents.remote_agent import get_subagent_user_id
+
+
+def _agent() -> GenericLangGraphReactAgent:
+    return GenericLangGraphReactAgent(
+        agent_name="react_identity_test",
+        description="Test agent.",
+        instructions="Test instructions.",
+        chat_model=None,
+        response_format=None,
+    )
+
+
+@pytest.mark.asyncio
+async def test_react_agent_invoke_scopes_user_id_for_subagent_tools() -> None:
+    captured: dict[str, str | None] = {}
+
+    class Graph:
+        async def ainvoke(self, inputs, config):
+            captured["user_id"] = get_subagent_user_id()
+            return {"messages": []}
+
+    agent = _agent()
+    agent.graph = Graph()
+
+    await agent.invoke("Analyze the project.", "session-123", user_id="user-456")
+
+    assert captured == {"user_id": "user-456"}
+    assert get_subagent_user_id() is None
+
+
+@pytest.mark.asyncio
+async def test_react_agent_stream_scopes_user_id_for_subagent_tools() -> None:
+    captured: dict[str, str | None] = {}
+
+    class Graph:
+        async def astream(self, inputs, config, stream_mode):
+            captured["user_id"] = get_subagent_user_id()
+            if False:
+                yield {}
+
+    agent = _agent()
+    agent.graph = Graph()
+
+    async for _ in agent.stream(
+        "Analyze the project.",
+        "session-123",
+        "task-123",
+        user_id="user-456",
+    ):
+        pass
+
+    assert captured == {"user_id": "user-456"}
+    assert get_subagent_user_id() is None

--- a/tests/test_react_subagent_identity.py
+++ b/tests/test_react_subagent_identity.py
@@ -4,7 +4,10 @@ import pytest
 from langchain_core.messages import AIMessage
 
 from automa_ai.agents.react_langgraph_agent import GenericLangGraphReactAgent
-from automa_ai.agents.remote_agent import get_subagent_user_id
+from automa_ai.agents.remote_agent import (
+    get_subagent_context_id,
+    get_subagent_user_id,
+)
 
 
 def _agent() -> GenericLangGraphReactAgent:
@@ -23,6 +26,7 @@ async def test_react_agent_invoke_scopes_user_id_for_subagent_tools() -> None:
 
     class Graph:
         async def ainvoke(self, inputs, config):
+            captured["context_id"] = get_subagent_context_id()
             captured["user_id"] = get_subagent_user_id()
             return {"messages": []}
 
@@ -31,7 +35,11 @@ async def test_react_agent_invoke_scopes_user_id_for_subagent_tools() -> None:
 
     await agent.invoke("Analyze the project.", "session-123", user_id="user-456")
 
-    assert captured == {"user_id": "user-456"}
+    assert captured == {
+        "context_id": "session-123",
+        "user_id": "user-456",
+    }
+    assert get_subagent_context_id() is None
     assert get_subagent_user_id() is None
 
 
@@ -41,6 +49,7 @@ async def test_react_agent_stream_scopes_user_id_for_subagent_tools() -> None:
 
     class Graph:
         async def astream(self, inputs, config, stream_mode):
+            captured["context_id"] = get_subagent_context_id()
             captured["user_id"] = get_subagent_user_id()
             if False:
                 yield {}
@@ -56,7 +65,11 @@ async def test_react_agent_stream_scopes_user_id_for_subagent_tools() -> None:
     ):
         pass
 
-    assert captured == {"user_id": "user-456"}
+    assert captured == {
+        "context_id": "session-123",
+        "user_id": "user-456",
+    }
+    assert get_subagent_context_id() is None
     assert get_subagent_user_id() is None
 
 
@@ -66,6 +79,7 @@ async def test_react_agent_stream_resets_user_id_before_early_stop() -> None:
 
     class Graph:
         async def astream(self, inputs, config, stream_mode):
+            captured["context_id"] = get_subagent_context_id()
             captured["user_id"] = get_subagent_user_id()
             yield {
                 "model": {
@@ -87,6 +101,10 @@ async def test_react_agent_stream_resets_user_id_before_early_stop() -> None:
     terminal_item = await anext(stream)
 
     assert terminal_item["is_task_complete"] is True
-    assert captured == {"user_id": "user-456"}
+    assert captured == {
+        "context_id": "session-123",
+        "user_id": "user-456",
+    }
+    assert get_subagent_context_id() is None
     assert get_subagent_user_id() is None
     await stream.aclose()


### PR DESCRIPTION
Problem
Remote A2A subagents did not receive the parent request’s user identity.
Although RemoteAgent accepted a user_id argument and could place it in outgoing A2A message metadata, the generated SubAgentSpec tool only forwarded context_id. As a result, the remote CE Expert request had no user identifier and failed when the service required metadata.userId.
This affected both streaming and non-streaming remote subagents.
Solution
Propagate the parent agent’s user ID through the subagent execution context:
Store user_id in a request-scoped context variable alongside context_id.
Set and reset it around LangGraph invoke and stream execution.
Forward it through make_subagent_tool and A2AToolAdapter to RemoteAgent.
Include both metadata.user_id for AUTOMA-AI compatibility and metadata.userId for CE Expert/API-client compatibility.
The user ID remains framework-controlled and is not exposed as an LLM tool parameter.
Validation
Added regression coverage for parent user-ID forwarding through a remote subagent tool.
Added coverage confirming outbound A2A metadata contains both identity keys.
Ran: uv run pytest -q tests/test_a2a_client_auth.py
Result: 17 passed.