### PR TITLE
Update message accumulator for Claude usage

### DIFF
--- a/automa_ai/agents/langgraph_chatagent.py
+++ b/automa_ai/agents/langgraph_chatagent.py
@@ -731,6 +731,9 @@ class GenericLangGraphChatAgent(BaseAgent):
                                     )
                             elif isinstance(ck, ToolMessage):
                                 tool_activity_started = True
+                                # Only text produced after the last tool
+                                # result belongs in the final artifact.
+                                message_accumulator.reset_turn_text()
                                 self.telemetry.event(
                                     "tool.message",
                                     attributes={

--- a/automa_ai/common/message_accumulator.py
+++ b/automa_ai/common/message_accumulator.py
@@ -172,6 +172,7 @@ class AIMessageAccumulator:
         """
         self._assistant_parts.clear()
         self._artifact_parts.clear()
+        self._tool_calls.clear()
         self._in_artifact = False
         self._carry = ""
 

--- a/automa_ai/common/message_accumulator.py
+++ b/automa_ai/common/message_accumulator.py
@@ -163,6 +163,18 @@ class AIMessageAccumulator:
         self._carry = ""
         return message
 
+    def reset_turn_text(self) -> None:
+        """Drop the text accumulated so far, keeping usage/metadata totals.
+
+        Called at a tool-call boundary. Models such as Claude emit a
+        conversational preamble in the same AIMessage as their tool calls,
+        but that text is only useful as an intermediate status update.
+        """
+        self._assistant_parts.clear()
+        self._artifact_parts.clear()
+        self._in_artifact = False
+        self._carry = ""
+
     def get_last_assistant_text(self) -> str | None:
         """
         Get the last assistant text.

--- a/automa_ai/common/message_accumulator_test.py
+++ b/automa_ai/common/message_accumulator_test.py
@@ -605,6 +605,27 @@ class TestComplexScenarios:
         assert acc.get_assistant_text() == "final answer"
         assert acc.get_artifact_text() is None
 
+    def test_reset_turn_text_clears_tool_calls(self):
+        """Tool calls before reset must not appear in the final message."""
+        acc = AIMessageAccumulator()
+
+        tool_call = {
+            "id": "123",
+            "name": "search",
+            "args": {"query": "test"},
+            "type": "tool_call",
+        }
+        acc.add_chunk(
+            AIMessageChunk(content="I'll search for that.", tool_calls=[tool_call])
+        )
+        acc.reset_turn_text()  # tool result arrived
+
+        acc.add_chunk(AIMessageChunk(content="Here's what I found."))
+
+        msg = acc.finalize()
+        assert msg.content == "Here's what I found."
+        assert msg.tool_calls == []
+
 
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])

--- a/automa_ai/common/message_accumulator_test.py
+++ b/automa_ai/common/message_accumulator_test.py
@@ -554,6 +554,56 @@ class TestComplexScenarios:
 
         msg = acc.finalize()
         assert msg.content == "I'll create that for you:  There you go! const x = 42;"
+        
+    def test_reset_turn_text_drops_pre_tool_preamble(self):
+        """Tool-call preambles must not be joined onto the final answer."""
+        acc = AIMessageAccumulator()
+
+        # Turn 1: Claude's preamble that accompanies its tool_calls.
+        acc.add_chunk(
+            AIMessageChunk(
+                content="I'll load the project inspector skill.",
+                usage_metadata={
+                    "input_tokens": 10,
+                    "output_tokens": 5,
+                    "total_tokens": 15,
+                },
+            )
+        )
+        acc.reset_turn_text()  # tool result arrived
+
+        # Turn 2: another preamble before the second tool call.
+        acc.add_chunk(AIMessageChunk(content="Now I'll query your project:"))
+        acc.reset_turn_text()
+
+        # Final turn: the actual answer.
+        acc.add_chunk(
+            AIMessageChunk(
+                content="Your project has 4 walls.",
+                usage_metadata={
+                    "input_tokens": 20,
+                    "output_tokens": 7,
+                    "total_tokens": 27,
+                },
+            )
+        )
+
+        assert acc.get_assistant_text() == "Your project has 4 walls."
+        msg = acc.finalize()
+        assert msg.content == "Your project has 4 walls."
+        # Usage totals span the whole run even though text was reset.
+        assert msg.usage_metadata["output_tokens"] == 12
+
+    def test_reset_turn_text_clears_partial_artifact_state(self):
+        """A reset mid-artifact must not leak into the next turn's routing."""
+        acc = AIMessageAccumulator()
+
+        acc.add_chunk(AIMessageChunk(content=f"stale {ARTIFACT_START}partial"))
+        acc.reset_turn_text()
+
+        acc.add_chunk(AIMessageChunk(content="final answer"))
+        assert acc.get_assistant_text() == "final answer"
+        assert acc.get_artifact_text() is None
 
 
 if __name__ == "__main__":

--- a/automa_ai/common/message_accumulator_test.py
+++ b/automa_ai/common/message_accumulator_test.py
@@ -554,7 +554,7 @@ class TestComplexScenarios:
 
         msg = acc.finalize()
         assert msg.content == "I'll create that for you:  There you go! const x = 42;"
-        
+
     def test_reset_turn_text_drops_pre_tool_preamble(self):
         """Tool-call preambles must not be joined onto the final answer."""
         acc = AIMessageAccumulator()

--- a/uv.lock
+++ b/uv.lock
@@ -359,7 +359,7 @@ wheels = [
 
 [[package]]
 name = "automa-ai"
-version = "0.7.3"
+version = "0.8.1"
 source = { editable = "." }
 dependencies = [
     { name = "a2a-sdk" },

--- a/uv.lock
+++ b/uv.lock
@@ -359,7 +359,7 @@ wheels = [
 
 [[package]]
 name = "automa-ai"
-version = "0.8.1"
+version = "0.7.3"
 source = { editable = "." }
 dependencies = [
     { name = "a2a-sdk" },


### PR DESCRIPTION

Fixes message accumulation for Claude models that emit conversational preambles alongside tool calls.

- Adds `reset_turn_text()` method to `AIMessageAccumulator` that drops accumulated text while preserving usage/metadata totals
- Calls `reset_turn_text()` when a `ToolMessage` is received, ensuring only text after the last tool result appears in the final response
- Prevents tool-call preambles (e.g., "I'll load the project inspector skill") from being concatenated onto the final answer